### PR TITLE
feat: Implement thumbnail generation for images

### DIFF
--- a/media_server/media_scanner.py
+++ b/media_server/media_scanner.py
@@ -2,10 +2,15 @@ import os
 import hashlib
 import mimetypes
 from absl import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
+from PIL import Image, ImageOps
 
 # Initialize mimetypes database
 mimetypes.init()
+
+THUMBNAIL_DIR_NAME = ".thumbnails"
+THUMBNAIL_SIZE = (256, 256)
+THUMBNAIL_EXTENSION = ".png"
 
 def get_file_sha256(file_path: str) -> Optional[str]:
     """Computes the SHA256 hash of a file."""
@@ -26,6 +31,57 @@ def is_media_file(file_path: str) -> bool:
     if mime_type:
         return mime_type.startswith('image/') or mime_type.startswith('video/')
     return False
+
+def generate_thumbnail(source_image_path: str,
+                       thumbnail_dir: str,
+                       sha256_hex: str,
+                       target_size: Tuple[int, int] = THUMBNAIL_SIZE) -> Optional[str]:
+    """
+    Generates a thumbnail for the given image.
+
+    Args:
+        source_image_path: Path to the original image.
+        thumbnail_dir: Directory where thumbnails are stored.
+        sha256_hex: SHA256 hash of the original image, used as thumbnail filename.
+        target_size: A tuple (width, height) for the thumbnail.
+
+    Returns:
+        Path to the generated thumbnail, or None if generation failed.
+    """
+    thumbnail_filename = sha256_hex + THUMBNAIL_EXTENSION
+    thumbnail_path = os.path.join(thumbnail_dir, thumbnail_filename)
+
+    if os.path.exists(thumbnail_path):
+        # Could add mtime check here if we want to update existing thumbnails
+        # For now, if it exists, we assume it's correct.
+        logging.debug(f"Thumbnail already exists: {thumbnail_path}")
+        return thumbnail_path
+
+    try:
+        with Image.open(source_image_path) as img:
+            # Use ImageOps.fit to resize and crop if necessary,
+            # or create a letterbox/pillarbox effect.
+            # To maintain aspect ratio and add transparent bands:
+            img.thumbnail(target_size, Image.Resampling.LANCZOS)
+
+            # Create a new image with transparent background
+            final_thumb = Image.new("RGBA", target_size, (0, 0, 0, 0))
+
+            # Calculate position to paste the resized image (centered)
+            paste_x = (target_size[0] - img.width) // 2
+            paste_y = (target_size[1] - img.height) // 2
+
+            final_thumb.paste(img, (paste_x, paste_y))
+
+            final_thumb.save(thumbnail_path, "PNG")
+            logging.info(f"Generated thumbnail: {thumbnail_path} for {source_image_path}")
+            return thumbnail_path
+    except FileNotFoundError:
+        logging.error(f"Source image not found for thumbnail generation: {source_image_path}")
+        return None
+    except Exception as e:
+        logging.error(f"Failed to generate thumbnail for {source_image_path}: {e}")
+        return None
 
 def scan_directory(storage_dir: str,
                    existing_data: Optional[Dict[str, dict]] = None,
@@ -49,6 +105,10 @@ def scan_directory(storage_dir: str,
         logging.error(f"Storage directory not found: {storage_dir}")
         return {}
 
+    thumbnail_dir_path = os.path.join(storage_dir, THUMBNAIL_DIR_NAME)
+    os.makedirs(thumbnail_dir_path, exist_ok=True)
+    logging.info(f"Thumbnail directory ensured at: {thumbnail_dir_path}")
+
     current_media_data = {}
     if existing_data and rescan:
         logging.info(f"Rescanning directory: {storage_dir}")
@@ -61,6 +121,14 @@ def scan_directory(storage_dir: str,
             if not file_path or not os.path.isfile(file_path):
                 logging.info(f"File {data.get('filename', 'unknown')} (SHA: {sha256_hex}) no longer exists or path is missing. Removing.")
                 shas_to_remove.append(sha256_hex)
+                # Delete corresponding thumbnail
+                thumbnail_to_delete = os.path.join(thumbnail_dir_path, sha256_hex + THUMBNAIL_EXTENSION)
+                if os.path.exists(thumbnail_to_delete):
+                    try:
+                        os.remove(thumbnail_to_delete)
+                        logging.info(f"Deleted thumbnail for removed file: {thumbnail_to_delete}")
+                    except OSError as e:
+                        logging.error(f"Error deleting thumbnail {thumbnail_to_delete}: {e}")
                 continue
 
             try:
@@ -72,19 +140,49 @@ def scan_directory(storage_dir: str,
                         # SHA changed, means content changed. Remove old, new one will be added.
                         shas_to_remove.append(sha256_hex)
                         logging.debug(f"SHA changed for {data['filename']}. Old SHA: {sha256_hex}, New SHA: {new_sha256_hex}")
-                        # The new entry will be added during the walk phase
+                        # Delete old thumbnail
+                        old_thumbnail_to_delete = os.path.join(thumbnail_dir_path, sha256_hex + THUMBNAIL_EXTENSION)
+                        if os.path.exists(old_thumbnail_to_delete):
+                            try:
+                                os.remove(old_thumbnail_to_delete)
+                                logging.info(f"Deleted old thumbnail due to SHA change: {old_thumbnail_to_delete}")
+                            except OSError as e:
+                                logging.error(f"Error deleting old thumbnail {old_thumbnail_to_delete}: {e}")
+                        # The new entry and its thumbnail will be added during the walk phase
                     elif new_sha256_hex == sha256_hex:
                         # Content is same (SHA same) but mtime changed. Just update mtime.
                         current_media_data[sha256_hex]['last_modified'] = current_last_modified
                         logging.debug(f"Timestamp updated for {data['filename']} (SHA: {sha256_hex})")
+                        # Optionally, regenerate thumbnail if mtime changes, even if SHA is same
+                        # For now, we don't regenerate if SHA is the same.
                     elif not new_sha256_hex: # Error hashing
                         shas_to_remove.append(sha256_hex) # Remove if hashing failed
+                        # Also remove its thumbnail
+                        thumbnail_to_delete = os.path.join(thumbnail_dir_path, sha256_hex + THUMBNAIL_EXTENSION)
+                        if os.path.exists(thumbnail_to_delete):
+                            try:
+                                os.remove(thumbnail_to_delete)
+                                logging.info(f"Deleted thumbnail due to hashing error on original: {thumbnail_to_delete}")
+                            except OSError as e:
+                                logging.error(f"Error deleting thumbnail {thumbnail_to_delete}: {e}")
+
             except OSError as e:
                 logging.error(f"Could not get metadata for file {file_path} during rescan: {e}")
                 shas_to_remove.append(sha256_hex) # Remove if metadata access fails
+                 # Also remove its thumbnail
+                thumbnail_to_delete = os.path.join(thumbnail_dir_path, sha256_hex + THUMBNAIL_EXTENSION)
+                if os.path.exists(thumbnail_to_delete):
+                    try:
+                        os.remove(thumbnail_to_delete)
+                        logging.info(f"Deleted thumbnail due to metadata error on original: {thumbnail_to_delete}")
+                    except OSError as e_thumb:
+                        logging.error(f"Error deleting thumbnail {thumbnail_to_delete}: {e_thumb}")
+
 
         for sha in shas_to_remove:
-            del current_media_data[sha]
+            if sha in current_media_data: # Ensure it wasn't already removed by some other logic
+                 del current_media_data[sha]
+
 
         # Create a set of known file paths for quick lookup
         known_file_paths = {data['file_path'] for data in current_media_data.values() if 'file_path' in data}
@@ -94,11 +192,16 @@ def scan_directory(storage_dir: str,
         known_file_paths = set() # No known files yet
 
     # Walk the directory for new files or files not in existing_data (if rescanning)
-    for root, _, files in os.walk(storage_dir):
+    for root, dirs, files in os.walk(storage_dir):
+        # Exclude the thumbnail directory from scanning
+        if THUMBNAIL_DIR_NAME in dirs:
+            dirs.remove(THUMBNAIL_DIR_NAME)
+            logging.debug(f"Excluding thumbnail directory from scan: {os.path.join(root, THUMBNAIL_DIR_NAME)}")
+
         for filename in files:
             file_path = os.path.join(root, filename)
 
-            if not os.path.isfile(file_path):
+            if not os.path.isfile(file_path): # Should not happen with os.walk's files list but good practice
                 logging.debug(f"Skipping non-file item: {file_path}")
                 continue
 
@@ -109,10 +212,12 @@ def scan_directory(storage_dir: str,
                 logging.debug(f"Processing media file: {file_path}")
                 sha256_hex = get_file_sha256(file_path)
                 if sha256_hex:
-                    # If rescan=True, this will add new files.
-                    # If rescan=False (initial scan), this adds all files.
-                    # If a file was modified and its SHA changed, the old entry was removed,
-                    # and this block will add the new entry.
+                    # Generate thumbnail (it will check for existence internally)
+                    # This is done for both new files and files whose SHA changed (old entry removed).
+                    mime_type, _ = mimetypes.guess_type(file_path)
+                    if mime_type and mime_type.startswith('image/'): # Only generate for images
+                        generate_thumbnail(file_path, thumbnail_dir_path, sha256_hex)
+
                     if sha256_hex not in current_media_data or \
                        current_media_data[sha256_hex].get('file_path') != file_path: # Handle hash collisions or different paths
                         try:
@@ -127,6 +232,23 @@ def scan_directory(storage_dir: str,
                             logging.error(f"Could not get metadata for new/updated file {file_path}: {e}")
             else:
                 logging.debug(f"Skipping non-media file: {file_path}")
+
+    # Synchronize .thumbnails directory: remove any orphaned thumbnails
+    if os.path.exists(thumbnail_dir_path):
+        try:
+            for thumb_filename in os.listdir(thumbnail_dir_path):
+                if thumb_filename.endswith(THUMBNAIL_EXTENSION):
+                    thumb_sha = thumb_filename[:-len(THUMBNAIL_EXTENSION)]
+                    if thumb_sha not in current_media_data:
+                        orphaned_thumb_path = os.path.join(thumbnail_dir_path, thumb_filename)
+                        try:
+                            os.remove(orphaned_thumb_path)
+                            logging.info(f"Removed orphaned thumbnail: {orphaned_thumb_path}")
+                        except OSError as e:
+                            logging.error(f"Error removing orphaned thumbnail {orphaned_thumb_path}: {e}")
+        except OSError as e:
+            logging.error(f"Could not list thumbnail directory for cleanup {thumbnail_dir_path}: {e}")
+
 
     if rescan:
         logging.info(f"Rescan complete. Found {len(current_media_data)} media files.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 absl-py
 requests
+Pillow

--- a/tests/test_media_scanner.py
+++ b/tests/test_media_scanner.py
@@ -10,19 +10,45 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from media_server import media_scanner
+from PIL import Image
 
 # Helper to create dummy files with specific content and mtime
-def create_dummy_file(dir_path, filename, content="dummy content", mtime=None):
+def create_dummy_file(dir_path, filename, content="dummy content", mtime=None, image_details=None):
     filepath = os.path.join(dir_path, filename)
-    with open(filepath, "w") as f:
-        f.write(content)
+    if image_details: # Create a real (but basic) image file
+        try:
+            img = Image.new(image_details.get('mode', 'RGB'),
+                            image_details.get('size', (100,100)),
+                            image_details.get('color', 'blue'))
+            img.save(filepath, image_details.get('format', 'JPEG'))
+            # Note: content arg is ignored if image_details is provided, SHA will be of image file
+        except Exception as e:
+            # Fallback or error if Pillow fails (e.g. format not supported for saving)
+            # print(f"Error creating dummy image {filepath}: {e}. Falling back to text file.")
+            with open(filepath, "wb" if isinstance(content, bytes) else "w") as f: # write bytes if content is bytes
+                f.write(content) # Fallback content
+    else:
+        with open(filepath, "wb" if isinstance(content, bytes) else "w") as f:
+            f.write(content)
+
+
     if mtime is not None:
         os.utime(filepath, (mtime, mtime))
     return filepath
 
 # Helper to calculate SHA256 for verification
-def calculate_sha256(content_str):
-    return hashlib.sha256(content_str.encode('utf-8')).hexdigest()
+def calculate_sha256_str(content_str):
+    # Decode if bytes, because get_file_sha256 in media_scanner reads "rb" then decodes implicitly or explicitly for text files
+    # For this helper, we assume if it's bytes, it's meant to be treated as a binary file's content string representation
+    if isinstance(content_str, bytes):
+        content_to_hash = content_str
+    else:
+        content_to_hash = content_str.encode('utf-8')
+    return hashlib.sha256(content_to_hash).hexdigest()
+
+def calculate_sha256_file(filepath):
+    return media_scanner.get_file_sha256(filepath)
+
 
 class TestMediaScanner(unittest.TestCase):
 
@@ -31,19 +57,22 @@ class TestMediaScanner(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp(prefix="media_server_test_")
         self.subdir = os.path.join(self.test_dir, "subdir")
         os.makedirs(self.subdir)
+        self.thumbnail_dir_path = os.path.join(self.test_dir, media_scanner.THUMBNAIL_DIR_NAME)
+        # scan_directory should create self.thumbnail_dir_path
 
-        # Define some file contents and their expected SHA256 hashes
-        self.content_img1 = "this is image1"
-        self.hash_img1 = calculate_sha256(self.content_img1)
-        self.content_vid1 = "this is video1"
-        self.hash_vid1 = calculate_sha256(self.content_vid1)
-        self.content_img2 = "this is image2 in subdir"
-        self.hash_img2 = calculate_sha256(self.content_img2)
+        # For text-based dummy files for non-image media or simple tests
+        self.content_vid1 = b"this is video1" # Use bytes for content for consistency if some files are binary
+        self.hash_vid1 = calculate_sha256_str(self.content_vid1)
 
-        # Create dummy files
-        # mimetypes.guess_type relies on file extensions.
-        self.time_img1 = time.time() - 1000 # Ensure a distinct, old timestamp
-        self.file_img1 = create_dummy_file(self.test_dir, "image1.jpg", self.content_img1, mtime=self.time_img1)
+        # Create actual image files for thumbnail testing
+        self.time_img1 = time.time() - 1000
+        self.file_img1 = create_dummy_file(
+            self.test_dir, "image1.jpg",
+            content=b"fallback jpg content", # Fallback content if image creation fails
+            mtime=self.time_img1,
+            image_details={'size': (600, 400), 'color': 'red', 'format': 'JPEG'}
+        )
+        self.hash_img1 = calculate_sha256_file(self.file_img1) # SHA of actual image file
 
         self.time_vid1 = time.time() - 2000
         self.file_vid1 = create_dummy_file(self.test_dir, "video1.mp4", self.content_vid1, mtime=self.time_vid1)
@@ -51,18 +80,26 @@ class TestMediaScanner(unittest.TestCase):
         self.file_txt1 = create_dummy_file(self.test_dir, "document.txt", "this is a text document")
 
         self.time_img2 = time.time() - 500
-        self.file_img2_subdir = create_dummy_file(self.subdir, "image2.png", self.content_img2, mtime=self.time_img2)
+        self.file_img2_subdir = create_dummy_file(
+            self.subdir, "image2.png",
+            content=b"fallback png content",
+            mtime=self.time_img2,
+            image_details={'size': (300, 500), 'color': 'green', 'format': 'PNG'}
+        )
+        self.hash_img2 = calculate_sha256_file(self.file_img2_subdir)
 
-        self.file_unknown_ext = create_dummy_file(self.test_dir, "archive.xyz", "unknown extension")
+        self.file_img3_square = create_dummy_file(
+            self.test_dir, "square.jpg",
+            mtime=time.time() - 400,
+            image_details={'size': (400,400), 'color': 'blue', 'format': 'JPEG'}
+        )
+        self.hash_img3_square = calculate_sha256_file(self.file_img3_square)
 
-        # For testing unreadable file for hashing (though get_file_sha256 handles logging, not raising)
-        # self.unreadable_file = create_dummy_file(self.test_dir, "unreadable.jpg", "content")
-        # os.chmod(self.unreadable_file, 0o000) # Make unreadable - This might fail on some OS or with permissions
+
+        self.file_unknown_ext = create_dummy_file(self.test_dir, "archive.xyz", b"unknown extension")
 
     def tearDown(self):
         # Clean up the temporary directory
-        # if os.path.exists(self.unreadable_file): # Ensure it's readable to delete
-        #     os.chmod(self.unreadable_file, 0o600)
         shutil.rmtree(self.test_dir)
 
     def test_is_media_file(self):
@@ -78,13 +115,10 @@ class TestMediaScanner(unittest.TestCase):
         self.assertFalse(media_scanner.is_media_file("test.xyz")) # Unknown extension
         self.assertFalse(media_scanner.is_media_file("test_no_extension"))
 
-    def test_get_file_sha256(self):
-        # Test with a known file and content
+    def test_get_file_sha256(self): # Combined test for sha256
         expected_hash = self.hash_img1
         actual_hash = media_scanner.get_file_sha256(self.file_img1)
         self.assertEqual(actual_hash, expected_hash)
-
-        # Test with a non-existent file (should log error and return None)
         self.assertIsNone(media_scanner.get_file_sha256("non_existent_file.jpg"))
 
     def test_scan_directory_empty(self):
@@ -92,151 +126,226 @@ class TestMediaScanner(unittest.TestCase):
         os.makedirs(empty_dir)
         result = media_scanner.scan_directory(empty_dir)
         self.assertEqual(result, {})
+        self.assertTrue(os.path.isdir(os.path.join(empty_dir, media_scanner.THUMBNAIL_DIR_NAME)))
 
     def test_scan_directory_non_existent(self):
         result = media_scanner.scan_directory(os.path.join(self.test_dir, "does_not_exist"))
-        self.assertEqual(result, {}) # Should return empty dict and log error
+        self.assertEqual(result, {})
 
-    def test_scan_directory_with_media_and_other_files(self):
+    def _assert_thumbnail_properties(self, thumb_path, original_image_path, expected_sha):
+        self.assertTrue(os.path.exists(thumb_path), f"Thumbnail not found at {thumb_path}")
+        with Image.open(thumb_path) as thumb_img:
+            self.assertEqual(thumb_img.size, media_scanner.THUMBNAIL_SIZE, "Thumbnail dimensions are incorrect.")
+            self.assertEqual(thumb_img.format, 'PNG', "Thumbnail format is not PNG.")
+
+            with Image.open(original_image_path) as orig_img:
+                orig_w, orig_h = orig_img.size
+                thumb_w, thumb_h = media_scanner.THUMBNAIL_SIZE
+
+                if orig_w == orig_h: # Square image
+                    # For square images, there should be no transparency if scaled correctly
+                    # unless the image itself had alpha. Assuming opaque test images for simplicity.
+                    if thumb_img.mode == 'RGBA': # It will be RGBA due to Image.new("RGBA", ...)
+                        # Check that it's not fully transparent. Sum of alpha should be > 0.
+                        # For a perfectly opaque square image, all alpha values would be 255.
+                        # Sum would be 255 * thumb_w * thumb_h
+                        alpha_channel = thumb_img.getchannel('A')
+                        is_transparent_everywhere = all(p == 0 for p in alpha_channel.getdata())
+                        is_opaque_everywhere = all(p == 255 for p in alpha_channel.getdata())
+
+                        # If original was perfectly square and opaque, thumbnail should be opaque.
+                        # This depends on whether original test images are RGBA or RGB.
+                        # Our dummy square image is JPEG, so it's RGB.
+                        self.assertTrue(is_opaque_everywhere, "Square image thumbnail has unexpected transparency.")
+                else: # Non-square image, expect padding
+                    self.assertEqual(thumb_img.mode, 'RGBA', "Non-square image thumbnail is not RGBA (expected transparency).")
+                    # Check corners for transparency (alpha value is 0)
+                    self.assertEqual(thumb_img.getpixel((0,0))[3], 0, "Top-left pixel not transparent for non-square.")
+                    self.assertEqual(thumb_img.getpixel((thumb_w-1,0))[3], 0, "Top-right pixel not transparent for non-square.")
+                    self.assertEqual(thumb_img.getpixel((0,thumb_h-1))[3], 0, "Bottom-left pixel not transparent for non-square.")
+                    self.assertEqual(thumb_img.getpixel((thumb_w-1,thumb_h-1))[3], 0, "Bottom-right pixel not transparent for non-square.")
+
+                    # Check center area is not transparent (alpha value is 255)
+                    center_x, center_y = thumb_w // 2, thumb_h // 2
+                    self.assertEqual(thumb_img.getpixel((center_x, center_y))[3], 255, "Center pixel is transparent for non-square.")
+
+
+    def test_scan_directory_initial_scan_and_thumbnails(self):
         result = media_scanner.scan_directory(self.test_dir)
 
-        self.assertEqual(len(result), 3) # img1.jpg, video1.mp4, subdir/image2.png
+        self.assertEqual(len(result), 4) # img1.jpg, video1.mp4, subdir/image2.png, square.jpg
+        self.assertTrue(os.path.isdir(self.thumbnail_dir_path))
 
-        # Check img1.jpg
+        # Check img1.jpg (600x400, non-square)
         self.assertIn(self.hash_img1, result)
-        self.assertEqual(result[self.hash_img1]['filename'], "image1.jpg")
-        self.assertAlmostEqual(result[self.hash_img1]['last_modified'], self.time_img1, places=7)
-        self.assertEqual(result[self.hash_img1]['file_path'], self.file_img1)
+        thumb_path_img1 = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(thumb_path_img1, self.file_img1, self.hash_img1)
 
-        # Check video1.mp4
+        # Check square.jpg (400x400, square)
+        self.assertIn(self.hash_img3_square, result)
+        thumb_path_img3 = os.path.join(self.thumbnail_dir_path, self.hash_img3_square + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(thumb_path_img3, self.file_img3_square, self.hash_img3_square)
+
+
+        # Check video1.mp4 (no thumbnail expected)
         self.assertIn(self.hash_vid1, result)
-        self.assertEqual(result[self.hash_vid1]['filename'], "video1.mp4")
-        self.assertAlmostEqual(result[self.hash_vid1]['last_modified'], self.time_vid1, places=7)
-        self.assertEqual(result[self.hash_vid1]['file_path'], self.file_vid1)
+        expected_thumb_path_vid1 = os.path.join(self.thumbnail_dir_path, self.hash_vid1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertFalse(os.path.exists(expected_thumb_path_vid1))
 
-        # Check subdir/image2.png
+        # Check subdir/image2.png (300x500, non-square)
         self.assertIn(self.hash_img2, result)
-        self.assertEqual(result[self.hash_img2]['filename'], "image2.png")
-        self.assertAlmostEqual(result[self.hash_img2]['last_modified'], self.time_img2, places=7)
-        self.assertEqual(result[self.hash_img2]['file_path'], self.file_img2_subdir)
+        thumb_path_img2 = os.path.join(self.thumbnail_dir_path, self.hash_img2 + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(thumb_path_img2, self.file_img2_subdir, self.hash_img2)
 
-        # Ensure text.txt and archive.xyz were not included
-        for sha, data in result.items():
-            self.assertNotIn(data['filename'], ["document.txt", "archive.xyz"])
+        # Ensure .thumbnails directory content is not in scan results
+        for item_sha in result:
+            self.assertFalse(media_scanner.THUMBNAIL_DIR_NAME in result[item_sha]['file_path'])
 
-    def test_rescan_directory_no_changes(self):
+    def test_rescan_no_changes(self):
         initial_scan = media_scanner.scan_directory(self.test_dir)
-        rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
-        self.assertEqual(initial_scan, rescan_result)
-
-    def test_rescan_directory_add_file(self):
-        initial_scan = media_scanner.scan_directory(self.test_dir)
-
-        # Add a new file
-        time_new_img = time.time() - 200
-        content_new_img = "new image content"
-        hash_new_img = calculate_sha256(content_new_img)
-        file_new_img = create_dummy_file(self.test_dir, "new_image.gif", content_new_img, mtime=time_new_img)
+        thumb_path_img1 = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertTrue(os.path.exists(thumb_path_img1))
 
         rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
+        self.assertEqual(initial_scan, rescan_result) # Should be identical if no changes
+        self.assertTrue(os.path.exists(thumb_path_img1)) # Thumbnail still there
 
+    def test_rescan_add_image_file(self):
+        initial_scan = media_scanner.scan_directory(self.test_dir)
+        new_img_path = create_dummy_file(
+            self.test_dir, "new_image.gif",
+            mtime=time.time() -100, # ensure different mtime
+            image_details={'size': (50,70), 'format': 'GIF'} # Non-square GIF
+        )
+        new_img_hash = calculate_sha256_file(new_img_path)
+
+        rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
         self.assertEqual(len(rescan_result), len(initial_scan) + 1)
-        self.assertIn(hash_new_img, rescan_result)
-        self.assertEqual(rescan_result[hash_new_img]['filename'], "new_image.gif")
-        self.assertAlmostEqual(rescan_result[hash_new_img]['last_modified'], time_new_img, places=7)
-        self.assertEqual(rescan_result[hash_new_img]['file_path'], file_new_img)
+        self.assertIn(new_img_hash, rescan_result)
+        new_thumb_path = os.path.join(self.thumbnail_dir_path, new_img_hash + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(new_thumb_path, new_img_path, new_img_hash)
 
-    def test_rescan_directory_remove_file(self):
+
+    def test_rescan_remove_image_file(self):
         initial_scan = media_scanner.scan_directory(self.test_dir)
+        thumb_path_img1 = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertTrue(os.path.exists(thumb_path_img1))
 
-        # Remove a file (image1.jpg)
         os.remove(self.file_img1)
-
         rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
 
         self.assertEqual(len(rescan_result), len(initial_scan) - 1)
         self.assertNotIn(self.hash_img1, rescan_result)
+        self.assertFalse(os.path.exists(thumb_path_img1))
 
-    def test_rescan_directory_modify_file_content_changes_sha(self):
+    def test_rescan_modify_image_content_sha_changes(self):
         initial_scan = media_scanner.scan_directory(self.test_dir)
+        old_thumb_path_img1 = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertTrue(os.path.exists(old_thumb_path_img1))
 
-        # Modify content of image1.jpg (changes SHA)
-        new_content_img1 = "modified image1 content"
-        new_hash_img1 = calculate_sha256(new_content_img1)
-        # Ensure mtime also changes, as real modifications would
-        new_time_img1 = time.time() - 100
-        create_dummy_file(self.test_dir, "image1.jpg", new_content_img1, mtime=new_time_img1) # Overwrites
+        # Overwrite self.file_img1 with new content/image
+        create_dummy_file(
+            self.test_dir, os.path.basename(self.file_img1), # ensure same filename
+            mtime=time.time() - 50, # ensure different mtime
+            image_details={'size': (350, 350), 'color': 'purple', 'format': 'JPEG'} # New square image
+        )
+        new_hash_img1 = calculate_sha256_file(self.file_img1) # Recalculate hash for the modified file
+        self.assertNotEqual(self.hash_img1, new_hash_img1, "SHA should change after content modification.")
 
         rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
 
-        self.assertEqual(len(rescan_result), len(initial_scan)) # Same number of files
-        self.assertNotIn(self.hash_img1, rescan_result) # Old SHA should be gone
-        self.assertIn(new_hash_img1, rescan_result) # New SHA should be present
-        self.assertEqual(rescan_result[new_hash_img1]['filename'], "image1.jpg")
-        self.assertAlmostEqual(rescan_result[new_hash_img1]['last_modified'], new_time_img1, places=7)
-
-    def test_rescan_directory_modify_file_mtime_only(self):
-        initial_scan = media_scanner.scan_directory(self.test_dir)
-        self.assertIn(self.hash_img1, initial_scan) # Ensure file is in initial scan
-        original_mtime_from_initial_scan = initial_scan[self.hash_img1]['last_modified']
-
-        # Modify mtime of image1.jpg, content (and SHA) remains the same
-        # Ensure new_time_img1 is significantly different and later.
-        new_time_img1 = time.time() + 100 # Clearly different and in the future relative to self.time_img1
-        self.assertNotAlmostEqual(original_mtime_from_initial_scan, new_time_img1, places=7) # Verify it's different beforehand
-
-        os.utime(self.file_img1, (new_time_img1, new_time_img1))
-
-        # Perform the rescan
-        rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
-
-        # Basic checks
         self.assertEqual(len(rescan_result), len(initial_scan))
-        self.assertIn(self.hash_img1, rescan_result) # SHA is the same
-        self.assertEqual(rescan_result[self.hash_img1]['filename'], "image1.jpg")
+        self.assertNotIn(self.hash_img1, rescan_result) # Old SHA removed
+        self.assertFalse(os.path.exists(old_thumb_path_img1)) # Old thumbnail deleted
 
-        # Check that the last_modified time IS updated in the rescan_result
-        self.assertAlmostEqual(rescan_result[self.hash_img1]['last_modified'], new_time_img1, places=7)
+        self.assertIn(new_hash_img1, rescan_result) # New SHA added
+        new_thumb_path_img1 = os.path.join(self.thumbnail_dir_path, new_hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(new_thumb_path_img1, self.file_img1, new_hash_img1) # Check new thumbnail
 
-        # Ensure the original entry in initial_scan was indeed different, confirming the update happened in rescan_result
-        self.assertNotAlmostEqual(original_mtime_from_initial_scan, rescan_result[self.hash_img1]['last_modified'], places=7,
-                                  msg="Timestamp in rescan_result should be updated and different from initial_scan's timestamp.")
-        self.assertAlmostEqual(original_mtime_from_initial_scan, self.time_img1, places=7,
-                                  msg="Timestamp in initial_scan should match the original self.time_img1.")
 
+    def test_rescan_modify_image_mtime_only_no_thumbnail_regen(self):
+        initial_scan = media_scanner.scan_directory(self.test_dir)
+        thumb_path = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertTrue(os.path.exists(thumb_path))
+        thumb_mtime_before = os.path.getmtime(thumb_path)
+
+        time.sleep(0.01) # Ensure mtime can change noticeably if file is touched
+        new_mtime = time.time() + 100 # Make it distinct
+        os.utime(self.file_img1, (new_mtime, new_mtime))
+
+        rescan_result = media_scanner.scan_directory(self.test_dir, existing_data=initial_scan, rescan=True)
+
+        self.assertEqual(len(rescan_result), len(initial_scan))
+        self.assertIn(self.hash_img1, rescan_result)
+        self.assertAlmostEqual(rescan_result[self.hash_img1]['last_modified'], new_mtime, places=7)
+
+        self.assertTrue(os.path.exists(thumb_path))
+        thumb_mtime_after = os.path.getmtime(thumb_path)
+        self.assertEqual(thumb_mtime_before, thumb_mtime_after,
+                         "Thumbnail mtime changed, indicating regeneration for mtime-only file change, which is not desired.")
+
+
+    def test_thumbnail_cleanup_orphaned_and_non_image_in_thumbnails_dir(self):
+        media_scanner.scan_directory(self.test_dir) # Initial scan to create .thumbnails and valid thumbs
+        thumb_img1_path = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertTrue(os.path.exists(thumb_img1_path))
+
+        # Create orphaned thumbnail
+        orphaned_thumb_path = os.path.join(self.thumbnail_dir_path, "orphaned_sha123" + media_scanner.THUMBNAIL_EXTENSION)
+        Image.new('RGB', (10,10), color='pink').save(orphaned_thumb_path, 'PNG') # Dummy PNG
+        self.assertTrue(os.path.exists(orphaned_thumb_path))
+
+        # Create non-thumbnail file in .thumbnails
+        non_thumbnail_file_path = os.path.join(self.thumbnail_dir_path, "data.json")
+        with open(non_thumbnail_file_path, "w") as f: f.write("{}")
+        self.assertTrue(os.path.exists(non_thumbnail_file_path))
+
+        # Rescan (use existing_data=None for a full fresh scan to trigger cleanup based on current state)
+        current_media = media_scanner.scan_directory(self.test_dir, rescan=False) # This scan itself will perform cleanup
+
+        self.assertTrue(os.path.exists(thumb_img1_path)) # Valid thumbnail remains
+        self.assertFalse(os.path.exists(orphaned_thumb_path)) # Orphaned .png thumbnail removed
+        self.assertTrue(os.path.exists(non_thumbnail_file_path)) # Non-thumbnail file remains
+
+    def test_thumbnail_generation_for_image_in_subdir(self):
+        # This is implicitly tested by test_scan_directory_initial_scan_and_thumbnails
+        # but an explicit check can be here too.
+        result = media_scanner.scan_directory(self.test_dir)
+        self.assertIn(self.hash_img2, result) # img2 is in self.subdir
+        thumb_path_img2 = os.path.join(self.thumbnail_dir_path, self.hash_img2 + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(thumb_path_img2, self.file_img2_subdir, self.hash_img2)
 
     def test_scan_directory_permissions_error_on_metadata(self):
         # This test is tricky to set up reliably across platforms for getmtime.
         # media_scanner logs errors from os.path.getmtime and skips the file.
-        # We can simulate by creating a file where getmtime might fail,
-        # but a more direct way is to ensure the logic handles it.
-        # For now, we trust the try-except block in scan_directory.
-        # If a file hash is None (e.g., due to read error for hashing), it's skipped.
-        # If getmtime fails, it's also logged and skipped.
+        tricky_file_path = create_dummy_file(
+            self.test_dir, "tricky.jpg",
+            image_details={'size':(20,20), 'format':'JPEG'}
+        )
+        hash_tricky = calculate_sha256_file(tricky_file_path)
 
-        # Create a file, then remove it before scan_directory tries to getmtime (simulates race condition)
-        # This isn't perfect but tests one path of os.stat failure.
-        tricky_file_path = create_dummy_file(self.test_dir, "tricky.jpg", "content")
 
-        original_getmtime = os.path.getmtime
+        original_os_path_getmtime = media_scanner.os.path.getmtime # Save original from module
         def mock_getmtime(path):
             if "tricky.jpg" in path:
                 raise OSError("Simulated metadata read error")
-            return original_getmtime(path)
+            return original_os_path_getmtime(path) # Call original for other files
 
         media_scanner.os.path.getmtime = mock_getmtime
 
-        result = media_scanner.scan_directory(self.test_dir)
+        # Perform a scan. Initial data is empty or non-existent for this particular tricky file.
+        result = media_scanner.scan_directory(self.test_dir, existing_data={}, rescan=True)
 
-        media_scanner.os.path.getmtime = original_getmtime # Restore
+        media_scanner.os.path.getmtime = original_os_path_getmtime # Restore
 
-        # tricky.jpg should not be in the results
-        tricky_hash = calculate_sha256("content")
-        self.assertNotIn(tricky_hash, result, "File with simulated getmtime error should be skipped.")
-        # Other files should still be there
+        self.assertNotIn(hash_tricky, result, "File with simulated getmtime error should be skipped.")
+        thumb_tricky_path = os.path.join(self.thumbnail_dir_path, hash_tricky + media_scanner.THUMBNAIL_EXTENSION)
+        self.assertFalse(os.path.exists(thumb_tricky_path),
+                         "Thumbnail for file with getmtime error should not exist or be cleaned up if error happens during rescan logic for it.")
+
+        # Other files should still be there and have thumbnails
         self.assertIn(self.hash_img1, result)
-        self.assertIn(self.hash_vid1, result)
-        self.assertIn(self.hash_img2, result)
+        self.assertTrue(os.path.exists(os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit introduces automatic thumbnail generation for image files during media scanning.

Key changes:
- Added Pillow library for image manipulation.
- Implemented `generate_thumbnail` function in `media_scanner.py` to create 256x256 PNG thumbnails.
  - Thumbnails maintain original aspect ratio by adding transparent padding if the source image is not square.
  - Thumbnail filenames are the SHA256 hash of the original image.
- Modified `scan_directory` in `media_scanner.py`:
  - Creates a `.thumbnails` directory in the storage root if it doesn't exist.
  - Excludes the `.thumbnails` directory from media scanning.
  - Calls `generate_thumbnail` for all identified image files.
  - Synchronizes thumbnails:
    - Deletes thumbnails if the original image is removed or modified (SHA changes).
    - Clears orphaned thumbnails from the `.thumbnails` directory.
- Updated `tests/test_media_scanner.py` with comprehensive tests for:
  - Thumbnail creation, correct dimensions, and aspect ratio handling.
  - Exclusion of `.thumbnails` directory from scan results.
  - Deletion of thumbnails for removed/modified media.
  - Cleanup of orphaned thumbnails.
  - Correct handling of square and non-square images.
  - Robustness in various rescan scenarios (add, remove, modify content, modify mtime).