### PR TITLE
docs: Update README for original_creation_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ media-server --storage_dir /path/to/your/media --port 8080 --rescan_interval 300
 ### API Endpoints
 
 -   **GET /list**: Returns a JSON object mapping the SHA256 hash of each media file
-    to its filename and last modified timestamp.
+    to its details. These details include:
+    -   `filename`: The name of the file.
+    -   `last_modified`: The last modification timestamp of the file (from the filesystem).
+    -   `file_path`: The full path to the file.
+    -   `original_creation_date`: The original creation timestamp of the media. For images, this is extracted from the EXIF 'DateTimeOriginal' tag if available. If EXIF data is not present or for other media types, this defaults to the file's creation time on the filesystem (ctime).
 
 Example response:
 ```json
@@ -37,13 +41,15 @@ Example response:
   "sha256_hash_1": {
     "filename": "image.jpg",
     "last_modified": 1678886400.0,
-    "file_path": "/path/to/your/media/image.jpg"
+    "file_path": "/path/to/your/media/image.jpg",
+    "original_creation_date": 1678880000.0
   },
   "sha256_hash_2": {
     "filename": "video.mp4",
     "last_modified": 1678886401.0,
-    "file_path": "/path/to/your/media/subdir/video.mp4"
+    "file_path": "/path/to/your/media/subdir/video.mp4",
+    "original_creation_date": 1678885000.0
   }
 }
 ```
-**Note:** The `"file_path"` field was added to the response objects.
+**Note:** The `"file_path"` and `"original_creation_date"` fields are included in the response objects. The `original_creation_date` will be derived from EXIF for images where possible.

--- a/tests/test_media_scanner.py
+++ b/tests/test_media_scanner.py
@@ -10,17 +10,53 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from media_server import media_scanner
-from PIL import Image
+from PIL import Image, ExifTags
+from datetime import datetime as dt # Alias to avoid conflict with time module
 
 # Helper to create dummy files with specific content and mtime
-def create_dummy_file(dir_path, filename, content="dummy content", mtime=None, image_details=None):
+def create_dummy_file(dir_path, filename, content="dummy content", mtime=None, image_details=None, exif_datetime_original_str=None):
     filepath = os.path.join(dir_path, filename)
+    exif_bytes = b''
     if image_details: # Create a real (but basic) image file
         try:
             img = Image.new(image_details.get('mode', 'RGB'),
                             image_details.get('size', (100,100)),
                             image_details.get('color', 'blue'))
-            img.save(filepath, image_details.get('format', 'JPEG'))
+
+            if exif_datetime_original_str and image_details.get('format', '').upper() in ['JPEG', 'TIFF']:
+                exif_dict = {}
+                # DateTimeOriginal tag ID is 36867
+                # Pillow expects exif data as a dict where keys are tag IDs from ExifTags.TAGS
+                # However, for saving, it needs the raw bytes from an Exif object.
+                # A simpler way for testing is to construct minimal EXIF bytes.
+                # For DateTimeOriginal (tag 36867 or 0x9003), the type is ASCII (2) and it needs a null terminator.
+                # Format: TIFF header (MM for big endian, II for little) -> IFD0 offset -> Number of tags -> Tag entries
+                # This is complex to build manually. Let's try using Pillow's Exif object if possible,
+                # or ensure the test image format supports EXIF (JPEG, TIFF).
+
+                # Pillow's img.save can take `exif=exif_bytes` argument.
+                # We need to construct these bytes.
+                # A more robust way is to load an image that has EXIF, modify it, and save.
+                # For controlled testing, we can try to build a minimal one.
+                # Example: exif_dict[ExifTags.TAGS.get('DateTimeOriginal')] = exif_datetime_original_str
+                # This is for reading. For writing, it's more direct with bytes.
+
+                try:
+                    # Get an Exif object. If one doesn't exist, Pillow creates it.
+                    exif = img.getexif()
+                    exif[0x9003] = exif_datetime_original_str  # Set DateTimeOriginal (tag ID 36867 or 0x9003)
+                    # The `save` method needs the EXIF data as bytes.
+                    exif_bytes_to_save = exif.tobytes()
+                    img.save(filepath, image_details.get('format', 'JPEG'), exif=exif_bytes_to_save)
+                except Exception as exif_write_e:
+                    # Adding a print for debugging in test environment if something goes wrong.
+                    print(f"Warning: Test utility could not write EXIF data to {filename}: {exif_write_e}")
+                    # Fallback to saving without EXIF if writing failed
+                    img.save(filepath, image_details.get('format', 'JPEG'))
+            else:
+                # No EXIF requested or not a suitable format, save normally.
+                img.save(filepath, image_details.get('format', 'JPEG'))
+
             # Note: content arg is ignored if image_details is provided, SHA will be of image file
         except Exception as e:
             # Fallback or error if Pillow fails (e.g. format not supported for saving)
@@ -94,6 +130,19 @@ class TestMediaScanner(unittest.TestCase):
             image_details={'size': (400,400), 'color': 'blue', 'format': 'JPEG'}
         )
         self.hash_img3_square = calculate_sha256_file(self.file_img3_square)
+
+        # Image with EXIF data
+        self.exif_date_str = "2001:01:01 10:00:00"
+        self.exif_datetime_obj = dt.strptime(self.exif_date_str, "%Y:%m:%d %H:%M:%S")
+        self.exif_timestamp = self.exif_datetime_obj.timestamp()
+        self.time_img_exif = time.time() - 300
+        self.file_img_exif = create_dummy_file(
+            self.test_dir, "image_with_exif.jpg",
+            mtime=self.time_img_exif,
+            image_details={'size': (80,90), 'color': 'yellow', 'format': 'JPEG'},
+            exif_datetime_original_str=self.exif_date_str
+        )
+        self.hash_img_exif = calculate_sha256_file(self.file_img_exif)
 
 
         self.file_unknown_ext = create_dummy_file(self.test_dir, "archive.xyz", b"unknown extension")
@@ -173,29 +222,57 @@ class TestMediaScanner(unittest.TestCase):
     def test_scan_directory_initial_scan_and_thumbnails(self):
         result = media_scanner.scan_directory(self.test_dir)
 
-        self.assertEqual(len(result), 4) # img1.jpg, video1.mp4, subdir/image2.png, square.jpg
+        # Expected number of files: img1.jpg, video1.mp4, subdir/image2.png, square.jpg, image_with_exif.jpg
+        self.assertEqual(len(result), 5)
         self.assertTrue(os.path.isdir(self.thumbnail_dir_path))
 
-        # Check img1.jpg (600x400, non-square)
+        # Check img1.jpg (no EXIF, should use ctime)
         self.assertIn(self.hash_img1, result)
+        self.assertIn('original_creation_date', result[self.hash_img1])
+        self.assertAlmostEqual(result[self.hash_img1]['original_creation_date'], os.path.getctime(self.file_img1), places=7)
         thumb_path_img1 = os.path.join(self.thumbnail_dir_path, self.hash_img1 + media_scanner.THUMBNAIL_EXTENSION)
         self._assert_thumbnail_properties(thumb_path_img1, self.file_img1, self.hash_img1)
 
-        # Check square.jpg (400x400, square)
+        # Check square.jpg (no EXIF, should use ctime)
         self.assertIn(self.hash_img3_square, result)
+        self.assertIn('original_creation_date', result[self.hash_img3_square])
+        self.assertAlmostEqual(result[self.hash_img3_square]['original_creation_date'], os.path.getctime(self.file_img3_square), places=7)
         thumb_path_img3 = os.path.join(self.thumbnail_dir_path, self.hash_img3_square + media_scanner.THUMBNAIL_EXTENSION)
         self._assert_thumbnail_properties(thumb_path_img3, self.file_img3_square, self.hash_img3_square)
 
-
-        # Check video1.mp4 (no thumbnail expected)
+        # Check video1.mp4 (no EXIF, should use ctime)
         self.assertIn(self.hash_vid1, result)
+        self.assertIn('original_creation_date', result[self.hash_vid1])
+        self.assertAlmostEqual(result[self.hash_vid1]['original_creation_date'], os.path.getctime(self.file_vid1), places=7)
         expected_thumb_path_vid1 = os.path.join(self.thumbnail_dir_path, self.hash_vid1 + media_scanner.THUMBNAIL_EXTENSION)
-        self.assertFalse(os.path.exists(expected_thumb_path_vid1))
+        self.assertFalse(os.path.exists(expected_thumb_path_vid1)) # No thumbnail for video
 
-        # Check subdir/image2.png (300x500, non-square)
+        # Check subdir/image2.png (no EXIF, should use ctime)
         self.assertIn(self.hash_img2, result)
+        self.assertIn('original_creation_date', result[self.hash_img2])
+        self.assertAlmostEqual(result[self.hash_img2]['original_creation_date'], os.path.getctime(self.file_img2_subdir), places=7)
         thumb_path_img2 = os.path.join(self.thumbnail_dir_path, self.hash_img2 + media_scanner.THUMBNAIL_EXTENSION)
         self._assert_thumbnail_properties(thumb_path_img2, self.file_img2_subdir, self.hash_img2)
+
+        # Check image_with_exif.jpg (should use EXIF date)
+        self.assertIn(self.hash_img_exif, result)
+        self.assertIn('original_creation_date', result[self.hash_img_exif])
+        # Ensure the EXIF writing worked, otherwise this test is not valid.
+        # We can try to read it back here to be sure.
+        try:
+            with Image.open(self.file_img_exif) as img_check:
+                exif_read_back = img_check._getexif()
+                self.assertIsNotNone(exif_read_back, "EXIF data was not written to test file.")
+                if exif_read_back: # if not None
+                     self.assertEqual(exif_read_back.get(36867), self.exif_date_str, "DateTimeOriginal not written correctly to test file.")
+        except Exception as e:
+            self.fail(f"Failed to read EXIF from test file {self.file_img_exif}: {e}")
+
+        self.assertAlmostEqual(result[self.hash_img_exif]['original_creation_date'], self.exif_timestamp, places=7,
+                               msg=f"EXIF original date mismatch. Expected {self.exif_timestamp}, got {result[self.hash_img_exif]['original_creation_date']}")
+        thumb_path_img_exif = os.path.join(self.thumbnail_dir_path, self.hash_img_exif + media_scanner.THUMBNAIL_EXTENSION)
+        self._assert_thumbnail_properties(thumb_path_img_exif, self.file_img_exif, self.hash_img_exif)
+
 
         # Ensure .thumbnails directory content is not in scan results
         for item_sha in result:


### PR DESCRIPTION
Updates the README.md to include documentation for the newly added 'original_creation_date' field in the API response.

Explains that this field is derived from EXIF 'DateTimeOriginal' for images, with a fallback to filesystem creation time (ctime). The example API response has also been updated to reflect this change.