### PR TITLE
feat: Refactor to Flask and add thumbnail endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ Example response:
 }
 ```
 **Note:** The `"file_path"` and `"original_creation_date"` fields are included in the response objects. The `original_creation_date` will be derived from EXIF for images where possible.
+
+-   **GET /thumbnail/<sha256_hex>**: Returns the thumbnail image (PNG) for the
+    given SHA256 hash if it exists.
+    -   `<sha256_hex>`: The SHA256 hash of the original media file. Must be 64 hexadecimal characters.
+    -   **Success (200 OK)**: Returns the thumbnail image with `Content-Type: image/png`.
+    -   **Not Found (404 Not Found)**: Returned if the SHA256 hash is unknown, if the corresponding media file does not have a thumbnail (e.g., it's a video or thumbnail generation failed), or if the thumbnail directory is missing.
+    -   **Bad Request (400 Bad Request)**: Returned if the provided `<sha256_hex>` is not a valid SHA256 hash format.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 absl-py
 requests
 Pillow
+Flask

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,342 +3,351 @@ import os
 import shutil
 import tempfile
 import json
-import threading
 import time
-import requests # For making HTTP requests
-from http.server import HTTPServer
-import socket # To find a free port
+from unittest import mock # For mocking time.sleep if needed later
 
 # Add project root to sys.path
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from media_server import server as media_server_module # aliasing to avoid conflict
+# Import the Flask app instance from the server module
+from media_server.server import app as flask_app # aliasing to avoid conflict
+from media_server.server import MEDIA_DATA_CACHE, MEDIA_DATA_LOCK # Direct access for tests
 from media_server import media_scanner # To get expected data
+from media_server import server as media_server_module # For FLAGS access
+from PIL import Image # For creating dummy image files
 
-# Helper to create dummy files (copied from test_media_scanner for independence if needed)
-def create_dummy_file(dir_path, filename, content="dummy content", mtime=None):
+# Helper to create dummy files
+def create_dummy_file(dir_path, filename, content="dummy content", mtime=None, image_details=None):
     filepath = os.path.join(dir_path, filename)
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
-    with open(filepath, "wb" if isinstance(content, bytes) else "w") as f:
-        f.write(content)
+    if image_details:
+        try:
+            img = Image.new(image_details.get('mode', 'RGB'),
+                            image_details.get('size', (100,100)),
+                            image_details.get('color', 'blue'))
+            # For thumbnail tests, format needs to be one that media_scanner can make a thumb from (e.g. JPEG, PNG)
+            img.save(filepath, image_details.get('format', 'JPEG'))
+        except Exception as e:
+            # Fallback to simple file if image creation fails
+            with open(filepath, "wb" if isinstance(content, bytes) else "w") as f:
+                f.write(content if content else b"image creation failed")
+    else:
+        with open(filepath, "wb" if isinstance(content, bytes) else "w") as f:
+            f.write(content)
+
     if mtime is not None:
         os.utime(filepath, (mtime, mtime))
     return filepath
 
-def get_free_port():
-    """Finds and returns an available port number."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-class TestServerIntegration(unittest.TestCase):
+class TestServerFlaskIntegration(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = tempfile.mkdtemp(prefix="media_server_int_test_")
-        cls.port = get_free_port()
-        cls.server_url = f"http://localhost:{cls.port}"
+        # Ensure absl flags are parsed. This is crucial for accessing FLAGS.storage_dir etc.
+        # In a test environment, absl_app.run() isn't called the same way.
+        if not media_server_module.FLAGS.is_parsed():
+            # Provide a default value for storage_dir for parsing,
+            # it will be overridden by test-specific values later.
+            # Using a dummy executable name for argv[0]
+            media_server_module.FLAGS([sys.argv[0], '--storage_dir=/tmp/dummy_for_parse'])
+
+        cls.test_dir = tempfile.mkdtemp(prefix="media_server_flask_test_")
+
+        # Configure Flask app for testing
+        flask_app.config['TESTING'] = True
+        flask_app.config['STORAGE_DIR'] = cls.test_dir
+        # Ensure THUMBNAIL_DIR is also configured if other parts of app use it
+        flask_app.config['THUMBNAIL_DIR'] = os.path.join(cls.test_dir, media_scanner.THUMBNAIL_DIR_NAME)
+
+
+        # Set absl flags used by the server module (especially for initial scan and background scanner)
+        # These flags are read by run_flask_app and background_scanner_task
+        media_server_module.FLAGS.storage_dir = cls.test_dir
+        media_server_module.FLAGS.port = 8000 # Port not really used by test_client
+        media_server_module.FLAGS.rescan_interval = 0 # Disable background scanner for most tests
 
         # Create some dummy media files
-        cls.img1_content = b"dummy image 1 content"
-        cls.img1_path = create_dummy_file(cls.test_dir, "image1.jpg", cls.img1_content)
+        # This one will be a basic text file, media_scanner won't make a thumbnail
+        cls.txt_file_content = b"dummy text file content"
+        cls.txt_file_path = create_dummy_file(cls.test_dir, "textfile.txt", cls.txt_file_content)
+
+        # This one will be a basic video-like file (by extension), no actual video content
+        # media_scanner won't make a thumbnail for this based on current logic (only for images)
         cls.vid1_content = b"dummy video 1 content"
         cls.vid1_path = create_dummy_file(cls.test_dir, "video1.mp4", cls.vid1_content)
-        create_dummy_file(cls.test_dir, "notes.txt", "not a media file") # Non-media file
 
-        # Pre-calculate expected data
-        cls.expected_media_data = media_scanner.scan_directory(cls.test_dir)
+        # This one is an actual image, for which a thumbnail should be generated
+        cls.img1_path = create_dummy_file(
+            cls.test_dir, "image1.jpg",
+            image_details={'size': (120, 80), 'color': 'red', 'format': 'JPEG'}
+        )
+        # Non-media file
+        create_dummy_file(cls.test_dir, "notes.txt", "not a media file")
 
-        # Start the server in a separate thread
-        # Mock FLAGS for the server instance
-        class MockFlags:
-            def __init__(self, storage_dir, port):
-                self.storage_dir = storage_dir
-                self.port = port
-                self.log_dir = None # Add any other flags server expects with default values
-                self.verbosity = 0 # Example, adjust if server uses it
 
-        media_server_module.FLAGS = MockFlags(cls.test_dir, cls.port)
+        # Perform initial scan to populate MEDIA_DATA_CACHE, simulating server startup
+        # This scan will also generate thumbnails for image1.jpg
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear() # Clear from previous tests if any
+            MEDIA_DATA_CACHE.update(media_scanner.scan_directory(cls.test_dir, rescan=False))
 
-        # The server's run_server function populates its own MEDIA_DATA_CACHE
-        # We need to ensure this happens before the httpd server starts serving requests.
-        # The current server.py structure does this sequentially.
+        cls.expected_media_data_after_setup = MEDIA_DATA_CACHE.copy()
+        # Store the SHA256 of the image for thumbnail tests
+        cls.img1_sha256 = None
+        for sha, data in cls.expected_media_data_after_setup.items():
+            if data['filename'] == "image1.jpg":
+                cls.img1_sha256 = sha
+                break
+        assert cls.img1_sha256 is not None, "Failed to get SHA256 for test image image1.jpg"
 
-        cls.httpd = HTTPServer(("", cls.port), media_server_module.MediaRequestHandler)
-        # Manually populate the server's cache using the initial scan logic from server.py
-        # This ensures the MEDIA_DATA_LOCK is respected if it were used during initial scan.
-        with media_server_module.MEDIA_DATA_LOCK:
-            media_server_module.MEDIA_DATA_CACHE = media_scanner.scan_directory(cls.test_dir, rescan=False)
+        # Store SHA256 for the video file (no thumbnail expected)
+        cls.vid1_sha256 = None
+        for sha, data in cls.expected_media_data_after_setup.items():
+            if data['filename'] == "video1.mp4":
+                cls.vid1_sha256 = sha
+                break
+        assert cls.vid1_sha256 is not None, "Failed to get SHA256 for test video video1.mp4"
 
-        cls.expected_media_data_after_setup = media_server_module.MEDIA_DATA_CACHE.copy()
-
-        # cls.httpd is already initialized above before populating the cache.
-        # The following lines were redundant and caused the port binding issue.
-        # cls.httpd = HTTPServer(("", cls.port), media_server_module.MediaRequestHandler)
-        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
-        cls.server_thread.start()
-        # No background scanner thread is started in this setUpClass by default.
-        # Tests needing the background scanner will set it up themselves.
-        time.sleep(0.1) # Give server a moment to start
+        cls.client = flask_app.test_client()
 
     @classmethod
     def tearDownClass(cls):
-        cls.httpd.shutdown()
-        cls.httpd.server_close()
         shutil.rmtree(cls.test_dir)
-        # Reset server's global state if necessary, e.g. MEDIA_DATA_CACHE
-        with media_server_module.MEDIA_DATA_LOCK:
-            media_server_module.MEDIA_DATA_CACHE = {}
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear()
+        # Reset any flags if necessary, though absl flags are tricky to reset fully.
+
+    def setUp(self):
+        # Ensure cache is in a known state before each test if tests modify it.
+        # For now, assuming tests either use the class-level setup or manage their own state.
+        # If tests modify MEDIA_DATA_CACHE, they should clean up or use a fresh setup.
+        # For safety, let's reset to initial state for each test, in case some test modifies it.
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear()
+            MEDIA_DATA_CACHE.update(self.expected_media_data_after_setup)
 
 
     def test_list_endpoint_success(self):
         """Test successful GET request to /list."""
-        response = requests.get(f"{self.server_url}/list")
+        response = self.client.get('/list')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers['Content-Type'], 'application/json')
+        self.assertEqual(response.content_type, 'application/json')
 
-        returned_data = response.json()
+        returned_data = response.json
         self.assertEqual(len(returned_data), 2) # Expecting two media files
-
-        # Verify content (hashes should match, filenames and timestamps)
-        # The structure is {hash: {'filename': ..., 'last_modified': ...}}
-        # We can compare it with our pre-calculated expected_media_data
-
-        # Normalize timestamps for comparison as JSON float precision might differ slightly
-        # from os.path.getmtime float precision.
-        # However, since we populate MEDIA_DATA_CACHE directly from scan_directory output,
-        # they should be identical.
-        # Compare with the cache state right after setup.
         self.assertEqual(returned_data, self.expected_media_data_after_setup)
-
 
     def test_invalid_path_returns_404(self):
         """Test GET request to an invalid path."""
-        response = requests.get(f"{self.server_url}/invalid_path")
+        response = self.client.get('/invalid_path')
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.headers['Content-Type'], 'text/plain')
-        self.assertIn(b"Error 404: Not Found", response.content)
+        # Flask's default 404 is HTML, but with jsonify for actual endpoints,
+        # a JSON 404 might be configured. For now, test default.
+        # For API consistency, one might add a @app.errorhandler(404) to return JSON.
+
+    def test_get_thumbnail_success(self):
+        """Test successfully retrieving an existing thumbnail."""
+        self.assertIsNotNone(self.img1_sha256, "Test setup error: img1_sha256 not set.")
+        # Ensure the thumbnail file actually exists where it should be
+        thumb_path = os.path.join(flask_app.config['THUMBNAIL_DIR'], f"{self.img1_sha256}{media_scanner.THUMBNAIL_EXTENSION}")
+        self.assertTrue(os.path.exists(thumb_path), f"Thumbnail file {thumb_path} does not exist. Scan/generation issue?")
+
+        response = self.client.get(f'/thumbnail/{self.img1_sha256}')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'image/png')
+        self.assertTrue(len(response.data) > 0, "Thumbnail data should not be empty.")
+
+    def test_get_thumbnail_not_found_for_video(self):
+        """Test 404 for a media type that doesn't generate thumbnails (e.g., video)."""
+        self.assertIsNotNone(self.vid1_sha256, "Test setup error: vid1_sha256 not set.")
+        # Ensure the thumbnail file does NOT exist for the video
+        thumb_path = os.path.join(flask_app.config['THUMBNAIL_DIR'], f"{self.vid1_sha256}{media_scanner.THUMBNAIL_EXTENSION}")
+        self.assertFalse(os.path.exists(thumb_path), f"Thumbnail file {thumb_path} should not exist for a video.")
+
+        response = self.client.get(f'/thumbnail/{self.vid1_sha256}')
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_thumbnail_not_found_sha_unknown(self):
+        """Test 404 for a correctly formatted but unknown SHA256."""
+        unknown_sha = "a" * 64 # Valid format, but unlikely to exist
+        response = self.client.get(f'/thumbnail/{unknown_sha}')
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_thumbnail_invalid_sha_format_too_short(self):
+        response = self.client.get('/thumbnail/12345')
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_thumbnail_invalid_sha_format_too_long(self):
+        response = self.client.get('/thumbnail/' + 'a' * 65)
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_thumbnail_invalid_sha_format_non_hex(self):
+        response = self.client.get('/thumbnail/' + 'g' * 64) # 'g' is not a hex character
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_thumbnail_when_thumbnail_dir_missing(self):
+        """Test 404 if the .thumbnails directory itself is missing."""
+        # This test requires altering the server's view of the thumbnail directory
+        # or creating a situation where it's not there.
+        original_thumbnail_dir = flask_app.config['THUMBNAIL_DIR']
+        temp_non_existent_thumb_dir = os.path.join(self.test_dir, ".nonexistentthumbnails")
+        flask_app.config['THUMBNAIL_DIR'] = temp_non_existent_thumb_dir # Point to a dir that won't exist
+
+        # Ensure the directory does not exist
+        if os.path.exists(temp_non_existent_thumb_dir):
+            shutil.rmtree(temp_non_existent_thumb_dir)
+
+        response = self.client.get(f'/thumbnail/{self.img1_sha256}')
+        self.assertEqual(response.status_code, 404) # Server should see dir missing
+
+        # Restore original config
+        flask_app.config['THUMBNAIL_DIR'] = original_thumbnail_dir
+
 
     def test_server_startup_with_empty_directory(self):
         """Test server behavior when storage_dir is empty."""
         empty_dir = tempfile.mkdtemp(prefix="media_server_empty_")
-        current_test_port = get_free_port() # Renamed to avoid conflict with cls.port or other scopes
 
-        class MockFlagsEmpty:
-            storage_dir = empty_dir
-            port = current_test_port # Use the correctly defined port for this test
-            log_dir = None
-            verbosity = 0
+        # Temporarily change app config for this test
+        original_storage_dir_flag = media_server_module.FLAGS.storage_dir
+        original_storage_dir_app_config = flask_app.config['STORAGE_DIR']
 
-        original_flags = media_server_module.FLAGS
-        media_server_module.FLAGS = MockFlagsEmpty
+        media_server_module.FLAGS.storage_dir = empty_dir
+        flask_app.config['STORAGE_DIR'] = empty_dir
 
-        # Manually trigger the scan and cache update for this specific test case
-        # This simulates what app.run -> run_server would do
-        temp_cache = media_scanner.scan_directory(empty_dir)
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear() # Clear current cache
+            # Simulate initial scan for the empty directory
+            MEDIA_DATA_CACHE.update(media_scanner.scan_directory(empty_dir, rescan=False))
 
-        # Temporarily override the global cache for the handler.
-        original_cache = media_server_module.MEDIA_DATA_CACHE
-        media_server_module.MEDIA_DATA_CACHE = temp_cache
-
-        httpd_empty = HTTPServer(("", current_test_port), media_server_module.MediaRequestHandler)
-        thread_empty = threading.Thread(target=httpd_empty.serve_forever, daemon=True)
-        thread_empty.start()
-        time.sleep(0.1)
-
-        response = requests.get(f"http://localhost:{current_test_port}/list")
+        response = self.client.get('/list')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {}) # Expect empty JSON object
+        self.assertEqual(response.json, {}) # Expect empty JSON object
 
-        httpd_empty.shutdown()
-        httpd_empty.server_close()
         shutil.rmtree(empty_dir)
 
-        # Restore original flags and cache for other tests
-        media_server_module.FLAGS = original_flags
-        media_server_module.MEDIA_DATA_CACHE = original_cache
-
-# Mock time.sleep to speed up tests involving background scanner
-class MockTime:
-    def __init__(self):
-        self.sleep_calls = []
-
-    def sleep(self, duration):
-        self.sleep_calls.append(duration)
-        # In a real test, we might advance a simulated clock here
-        # or simply record the call and return immediately.
-        return
-
-    def time(self): # Needed if other parts of tested code use time.time()
-        return time.time()
+        # Restore original config and cache state for other tests
+        media_server_module.FLAGS.storage_dir = original_storage_dir_flag
+        flask_app.config['STORAGE_DIR'] = original_storage_dir_app_config
+        with MEDIA_DATA_LOCK: # Restore main cache
+            MEDIA_DATA_CACHE.clear()
+            MEDIA_DATA_CACHE.update(self.expected_media_data_after_setup)
 
 
-class TestServerBackgroundScanning(unittest.TestCase):
+class TestServerFlaskBackgroundScanning(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Ensure absl flags are parsed for this test class as well.
+        if not media_server_module.FLAGS.is_parsed():
+            media_server_module.FLAGS([sys.argv[0], '--storage_dir=/tmp/dummy_for_bg_parse'])
+
     def setUp(self):
-        self.test_dir = tempfile.mkdtemp(prefix="media_server_bg_scan_")
-        self.port = get_free_port()
-        self.server_url = f"http://localhost:{self.port}"
+        self.test_dir = tempfile.mkdtemp(prefix="media_server_bg_scan_flask_")
 
-        # Mock FLAGS for the server instance
-        class MockFlags:
-            storage_dir = self.test_dir
-            port = self.port
-            rescan_interval = 0.1 # Small interval for testing
-            log_dir = None
-            verbosity = 0
+        flask_app.config['TESTING'] = True
+        flask_app.config['STORAGE_DIR'] = self.test_dir
+        self.client = flask_app.test_client()
 
-        self.original_flags = media_server_module.FLAGS
-        media_server_module.FLAGS = MockFlags()
+        # Set absl flags for this test suite
+        self.original_flags_storage_dir = media_server_module.FLAGS.storage_dir
+        self.original_flags_rescan_interval = media_server_module.FLAGS.rescan_interval
 
-        self.original_time_sleep = time.sleep
-        self.mock_time = MockTime()
-        time.sleep = self.mock_time.sleep # Patch time.sleep
+        media_server_module.FLAGS.storage_dir = self.test_dir
+        # rescan_interval is for the thread, not directly used by manual trigger.
+        media_server_module.FLAGS.rescan_interval = 0.01
 
         # Initial file
         self.img_content1 = b"image content one"
         self.img_path1 = create_dummy_file(self.test_dir, "imageA.jpg", self.img_content1, mtime=time.time()-100)
 
-        # Start server with background scanner
-        # The server's run_server logic will start the background thread.
-        # We need to run parts of run_server or simulate its effect.
+        # Initial scan
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear()
+            MEDIA_DATA_CACHE.update(media_scanner.scan_directory(self.test_dir, rescan=False))
+        self.initial_cache_state = MEDIA_DATA_CACHE.copy()
 
-        # 1. Initial scan
-        with media_server_module.MEDIA_DATA_LOCK:
-            media_server_module.MEDIA_DATA_CACHE = media_scanner.scan_directory(
-                media_server_module.FLAGS.storage_dir, rescan=False
-            )
-        self.initial_cache_state = media_server_module.MEDIA_DATA_CACHE.copy()
-
-        # 2. Start HTTP server (similar to TestServerIntegration)
-        self.httpd = HTTPServer(("", self.port), media_server_module.MediaRequestHandler)
-        self.server_thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
-        self.server_thread.start()
-
-        # No autonomous scanner thread started here. Scans will be triggered manually.
-        time.sleep(0.05) # Ensure HTTP server thread has started
 
     def trigger_scan_cycle(self):
         """Manually triggers one cycle of scanning logic."""
-        media_server_module.logging.info("Test: Manually triggering scan cycle...")
-        # The mocked time.sleep within this call path (if any internal part of scan_directory uses it)
-        # will be handled by self.mock_time.sleep, returning immediately.
-        # The FLAGS.rescan_interval is not used here as we are not simulating the timed loop.
-        try:
-            with media_server_module.MEDIA_DATA_LOCK:
-                updated_data = media_scanner.scan_directory(
-                    media_server_module.FLAGS.storage_dir, # Use storage_dir from mocked FLAGS
-                    existing_data=media_server_module.MEDIA_DATA_CACHE,
-                    rescan=True
-                )
-                media_server_module.MEDIA_DATA_CACHE = updated_data
-            media_server_module.logging.info("Test: Manual scan cycle complete.")
-        except Exception as e:
-            media_server_module.logging.error(f"Test: Error in manual scan cycle: {e}", exc_info=True)
-
+        with MEDIA_DATA_LOCK:
+            updated_data = media_scanner.scan_directory(
+                flask_app.config['STORAGE_DIR'], # Use app.config for consistency
+                existing_data=MEDIA_DATA_CACHE,
+                rescan=True
+            )
+            MEDIA_DATA_CACHE.clear()
+            MEDIA_DATA_CACHE.update(updated_data)
 
     def tearDown(self):
-        # No scanner_thread to stop or join as it's not started in setUp anymore
-
-        if hasattr(self, 'httpd') and self.httpd:
-            self.httpd.shutdown()
-            self.httpd.server_close()
-
-        if hasattr(self, 'server_thread') and self.server_thread.is_alive():
-            self.server_thread.join(timeout=0.5)
-
-
-        if os.path.exists(self.test_dir): # Check if test_dir was created
-            shutil.rmtree(self.test_dir)
-
-        if hasattr(self, 'original_flags'): # Check if original_flags was set
-             media_server_module.FLAGS = self.original_flags
-        if hasattr(self, 'original_time_sleep'): # Check if original_time_sleep was set
-            time.sleep = self.original_time_sleep
-
-        with media_server_module.MEDIA_DATA_LOCK:
-            media_server_module.MEDIA_DATA_CACHE = {}
-
+        shutil.rmtree(self.test_dir)
+        # Restore flags
+        media_server_module.FLAGS.storage_dir = self.original_flags_storage_dir
+        media_server_module.FLAGS.rescan_interval = self.original_flags_rescan_interval
+        with MEDIA_DATA_LOCK:
+            MEDIA_DATA_CACHE.clear()
 
     def test_background_scan_picks_up_new_file(self):
-        # 1. Verify initial state via /list
-        response1 = requests.get(f"{self.server_url}/list")
+        response1 = self.client.get('/list')
         self.assertEqual(response1.status_code, 200)
-        data1 = response1.json()
+        data1 = response1.json
         self.assertEqual(len(data1), 1)
         initial_sha1 = media_scanner.get_file_sha256(self.img_path1)
         self.assertIn(initial_sha1, data1)
 
-        # 2. Add a new file to the directory
         img_content2 = b"image content two"
         img_path2 = create_dummy_file(self.test_dir, "imageB.png", img_content2, mtime=time.time()-50)
         new_file_sha2 = media_scanner.get_file_sha256(img_path2)
 
-        # 3. Manually trigger the scan logic
         self.trigger_scan_cycle()
 
-        # 4. Verify /list shows the new file
-        response2 = requests.get(f"{self.server_url}/list")
+        response2 = self.client.get('/list')
         self.assertEqual(response2.status_code, 200)
-        data2 = response2.json()
-
-        self.assertEqual(len(data2), 2, f"Expected 2 files, got {len(data2)}. Data: {data2}")
+        data2 = response2.json
+        self.assertEqual(len(data2), 2)
         self.assertIn(initial_sha1, data2)
         self.assertIn(new_file_sha2, data2)
         self.assertEqual(data2[new_file_sha2]['filename'], "imageB.png")
-        # self.assertTrue(len(self.mock_time.sleep_calls) > 0, "time.sleep should have been called by background scanner")
-        # self.assertAlmostEqual(self.mock_time.sleep_calls[0], media_server_module.FLAGS.rescan_interval, places=7)
-        # The above sleep call checks are no longer relevant as the rescan_interval sleep is not part of trigger_scan_cycle
-
 
     def test_background_scan_picks_up_deleted_file(self):
-        # Initial state has one file (imageA.jpg)
         initial_sha1 = media_scanner.get_file_sha256(self.img_path1)
-        response1 = requests.get(f"{self.server_url}/list")
-        self.assertIn(initial_sha1, response1.json())
+        response1 = self.client.get('/list')
+        self.assertIn(initial_sha1, response1.json)
 
-        # Delete the file
         os.remove(self.img_path1)
-
-        # Manually trigger the scan logic
         self.trigger_scan_cycle()
 
-        response2 = requests.get(f"{self.server_url}/list")
-        data2 = response2.json()
-        self.assertEqual(len(data2), 0, f"Expected 0 files after deletion, got {len(data2)}. Data: {data2}")
+        response2 = self.client.get('/list')
+        data2 = response2.json
+        self.assertEqual(len(data2), 0)
         self.assertNotIn(initial_sha1, data2)
 
     def test_background_scan_picks_up_modified_file(self):
         initial_sha1 = media_scanner.get_file_sha256(self.img_path1)
-        response1 = requests.get(f"{self.server_url}/list")
-        self.assertIn(initial_sha1, response1.json())
-        original_mtime = response1.json()[initial_sha1]['last_modified']
+        response1 = self.client.get('/list')
+        self.assertIn(initial_sha1, response1.json)
+        original_mtime = response1.json[initial_sha1]['last_modified']
 
-        # Modify the file (content and mtime)
-        time.sleep(0.01)
+        time.sleep(0.01) # Ensure mtime is different
         new_mtime = time.time()
         modified_content = b"modified content for imageA"
-        create_dummy_file(self.test_dir, "imageA.jpg", modified_content, mtime=new_mtime)
+        # Re-create the file with new content and mtime
+        create_dummy_file(self.test_dir, os.path.basename(self.img_path1), modified_content, mtime=new_mtime)
         modified_sha1 = media_scanner.get_file_sha256(self.img_path1)
         self.assertNotEqual(initial_sha1, modified_sha1)
 
-        # Manually trigger the scan logic
         self.trigger_scan_cycle()
 
-        response2 = requests.get(f"{self.server_url}/list")
-        data2 = response2.json()
-
+        response2 = self.client.get('/list')
+        data2 = response2.json
         self.assertEqual(len(data2), 1)
         self.assertNotIn(initial_sha1, data2)
         self.assertIn(modified_sha1, data2)
-        self.assertEqual(data2[modified_sha1]['filename'], "imageA.jpg")
+        self.assertEqual(data2[modified_sha1]['filename'], os.path.basename(self.img_path1))
         self.assertNotAlmostEqual(data2[modified_sha1]['last_modified'], original_mtime, places=7)
-        self.assertAlmostEqual(data2[modified_sha1]['last_modified'], new_mtime, places=7)
+        # Ensure mtime is close to new_mtime. Precision can vary.
+        self.assertAlmostEqual(data2[modified_sha1]['last_modified'], new_mtime, places=2)
 
 
 if __name__ == '__main__':
-    # This allows running tests with `python tests/test_server.py`
-    # It's good practice to also be runnable via `python -m unittest discover`
     unittest.main()


### PR DESCRIPTION
This commit refactors the media server from Python's standard http.server to Flask for improved robustness, security, and maintainability.

It also introduces a new API endpoint:

GET /thumbnail/<sha256_hex>
- Serves the thumbnail image (PNG) for the given SHA256 hash.
- Validates the SHA256 format.
- Returns 404 if the thumbnail is not found or SHA is unknown.
- Returns 400 for invalid SHA256 format.

The existing /list endpoint functionality is maintained. All tests have been updated to use Flask's test client and new tests for the thumbnail endpoint have been added. The README.md has been updated to reflect these changes.