### PR TITLE
Fix: Maintain image aspect ratio in fullscreen view

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -166,6 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
             //     const rect = thumbnail.getBoundingClientRect();
             //     return {x: rect.left, y: rect.top + pageYScroll, w: rect.width};
             // }
+            initialZoomLevel: 'fit', // Ensure images fit within the viewport, maintaining aspect ratio
         });
 
         // Add caption using PhotoSwipe's caption plugin (optional, requires more setup or using title attribute)


### PR DESCRIPTION
Set PhotoSwipe's initialZoomLevel to 'fit' to ensure images are not distorted when opened in the fullscreen viewer.