### PR TITLE
Add media filtering by date and location

### DIFF
--- a/media_server/database.py
+++ b/media_server/database.py
@@ -445,3 +445,78 @@ def get_all_shas_in_db(db_path: str) -> List[str]:
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving all SHAs: {e}")
         return []
+
+def get_media_files_by_date(db_path: str, date: float) -> Dict[str, Dict[str, Any]]:
+    """
+    Retrieves media files created on a specific date.
+
+    Args:
+        db_path: The path to the database file.
+        date: The date to filter by, as a Unix timestamp.
+
+    Returns:
+        A dictionary of media files matching the date.
+    """
+    conn = get_db_connection(db_path)
+    media_dict = {}
+    try:
+        cursor = conn.cursor()
+        # Compare the date part of the timestamp
+        cursor.execute("SELECT * FROM media_files WHERE date(original_creation_date, 'unixepoch') = date(?, 'unixepoch')", (date,))
+        for row in cursor.fetchall():
+            media_dict[row['sha256_hex']] = dict(row)
+        return media_dict
+    except sqlite3.Error as e:
+        logging.error(f"Database error retrieving media files by date: {e}")
+        return {}
+
+def get_media_files_by_date_range(db_path: str, start_date: float, end_date: float) -> Dict[str, Dict[str, Any]]:
+    """
+    Retrieves media files created within a specific date range.
+
+    Args:
+        db_path: The path to the database file.
+        start_date: The start of the date range, as a Unix timestamp.
+        end_date: The end of the date range, as a Unix timestamp.
+
+    Returns:
+        A dictionary of media files within the date range.
+    """
+    conn = get_db_connection(db_path)
+    media_dict = {}
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM media_files WHERE original_creation_date BETWEEN ? AND ?", (start_date, end_date))
+        for row in cursor.fetchall():
+            media_dict[row['sha256_hex']] = dict(row)
+        return media_dict
+    except sqlite3.Error as e:
+        logging.error(f"Database error retrieving media files by date range: {e}")
+        return {}
+
+def get_media_files_by_location(db_path: str, city: str, country: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
+    """
+    Retrieves media files from a specific location.
+
+    Args:
+        db_path: The path to the database file.
+        city: The city to filter by.
+        country: The country to filter by (optional).
+
+    Returns:
+        A dictionary of media files matching the location.
+    """
+    conn = get_db_connection(db_path)
+    media_dict = {}
+    try:
+        cursor = conn.cursor()
+        if country:
+            cursor.execute("SELECT * FROM media_files WHERE city = ? AND country = ?", (city, country))
+        else:
+            cursor.execute("SELECT * FROM media_files WHERE city = ?", (city,))
+        for row in cursor.fetchall():
+            media_dict[row['sha256_hex']] = dict(row)
+        return media_dict
+    except sqlite3.Error as e:
+        logging.error(f"Database error retrieving media files by location: {e}")
+        return {}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,104 @@
+import unittest
+import os
+import tempfile
+import shutil
+import time
+import sys
+
+# Add project root to sys.path to allow direct import of media_server
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from media_server import database as db_utils
+
+class TestDataFiltering(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="db_filter_test_")
+        self.db_path = db_utils.get_db_path(self.test_dir)
+        db_utils.init_db(self.test_dir)
+
+        # Sample data
+        self.media_data = [
+            {
+                'sha256_hex': 'hash1', 'filename': 'file1.jpg', 'file_path': 'path1', 'last_modified': time.time(),
+                'original_creation_date': 1672531200, 'city': 'New York', 'country': 'USA' # 2023-01-01
+            },
+            {
+                'sha256_hex': 'hash2', 'filename': 'file2.jpg', 'file_path': 'path2', 'last_modified': time.time(),
+                'original_creation_date': 1675209600, 'city': 'Los Angeles', 'country': 'USA' # 2023-02-01
+            },
+            {
+                'sha256_hex': 'hash3', 'filename': 'file3.jpg', 'file_path': 'path3', 'last_modified': time.time(),
+                'original_creation_date': 1672531200, 'city': 'New York', 'country': 'USA' # 2023-01-01
+            },
+            {
+                'sha256_hex': 'hash4', 'filename': 'file4.jpg', 'file_path': 'path4', 'last_modified': time.time(),
+                'original_creation_date': 1677628800, 'city': 'London', 'country': 'UK' # 2023-03-01
+            }
+        ]
+
+        for data in self.media_data:
+            db_utils.add_or_update_media_file(self.db_path, data)
+
+    def tearDown(self):
+        db_utils.close_db_connection()
+        shutil.rmtree(self.test_dir)
+
+    def test_get_media_files_by_date(self):
+        # Test for a date with multiple files
+        results = db_utils.get_media_files_by_date(self.db_path, 1672531200)
+        self.assertEqual(len(results), 2)
+        self.assertIn('hash1', results)
+        self.assertIn('hash3', results)
+
+        # Test for a date with a single file
+        results = db_utils.get_media_files_by_date(self.db_path, 1675209600)
+        self.assertEqual(len(results), 1)
+        self.assertIn('hash2', results)
+
+        # Test for a date with no files
+        results = db_utils.get_media_files_by_date(self.db_path, 1672617600) # 2023-01-02
+        self.assertEqual(len(results), 0)
+
+    def test_get_media_files_by_date_range(self):
+        # Test range including multiple dates
+        results = db_utils.get_media_files_by_date_range(self.db_path, 1672531200, 1675209600)
+        self.assertEqual(len(results), 3)
+        self.assertIn('hash1', results)
+        self.assertIn('hash2', results)
+        self.assertIn('hash3', results)
+
+        # Test range with a single date
+        results = db_utils.get_media_files_by_date_range(self.db_path, 1672531200, 1672531200)
+        self.assertEqual(len(results), 2)
+
+        # Test range with no files
+        results = db_utils.get_media_files_by_date_range(self.db_path, 1680307200, 1682899200) # April 2023
+        self.assertEqual(len(results), 0)
+
+    def test_get_media_files_by_location(self):
+        # Test for a city with multiple files
+        results = db_utils.get_media_files_by_location(self.db_path, 'New York')
+        self.assertEqual(len(results), 2)
+        self.assertIn('hash1', results)
+        self.assertIn('hash3', results)
+
+        # Test for a city with a single file
+        results = db_utils.get_media_files_by_location(self.db_path, 'London')
+        self.assertEqual(len(results), 1)
+        self.assertIn('hash4', results)
+
+        # Test for a city with country
+        results = db_utils.get_media_files_by_location(self.db_path, 'New York', 'USA')
+        self.assertEqual(len(results), 2)
+
+        # Test for a city with wrong country
+        results = db_utils.get_media_files_by_location(self.db_path, 'New York', 'UK')
+        self.assertEqual(len(results), 0)
+
+        # Test for a non-existent city
+        results = db_utils.get_media_files_by_location(self.db_path, 'Paris')
+        self.assertEqual(len(results), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces new functionality to filter media files based on their creation date and location.

New functions added to `media_server/database.py`:
- `get_media_files_by_date`: Filters media by a single date.
- `get_media_files_by_date_range`: Filters media by a date range.
- `get_media_files_by_location`: Filters media by city and optionally country.

A new test file `tests/test_database.py` has been added to ensure the new filtering functions work as expected.