### PR TITLE
feat: Add settings UI

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -586,6 +586,11 @@ footer {
     color: white;
 }
 
+#saveSettings:disabled {
+    background-color: #a0a0a0;
+    cursor: not-allowed;
+}
+
 #cancelSettings {
     background-color: #e0e0e0;
     color: #333;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -478,6 +478,128 @@ footer {
     height: 24px; /* Ensure SVG is 24px */
 }
 
+/* Settings Button FAB Styles */
+.settings-btn {
+    position: fixed;
+    bottom: 88px; /* 20px (bottom) + 56px (upload btn height) + 12px (gap) */
+    right: 20px;
+    width: 56px;
+    height: 56px;
+    background-color: #6c757d; /* A neutral grey */
+    color: white;
+    border: none;
+    border-radius: 50%;
+    padding: 16px;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2), 0 2px 4px rgba(0,0,0,0.15);
+    transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out, box-shadow 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1050;
+}
+
+.settings-btn:hover {
+    background-color: #5a6268;
+    box-shadow: 0 6px 16px rgba(0,0,0,0.25), 0 3px 6px rgba(0,0,0,0.2);
+}
+
+.settings-btn:active {
+    background-color: #495057;
+    transform: scale(0.95);
+}
+
+.settings-btn svg {
+    fill: currentColor;
+    width: 24px;
+    height: 24px;
+}
+
+/* Settings Overlay Styles */
+.settings-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.settings-dialog {
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+    width: 90%;
+    max-width: 500px;
+}
+
+.settings-dialog h2 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    color: #333;
+}
+
+.settings-dialog form {
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-dialog label {
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: #555;
+}
+
+.settings-dialog input[type="text"],
+.settings-dialog input[type="number"],
+.settings-dialog select {
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+
+.settings-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.settings-actions button {
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+#saveSettings {
+    background-color: #007aff;
+    color: white;
+}
+
+#cancelSettings {
+    background-color: #e0e0e0;
+    color: #333;
+}
+
+.settings-error {
+    background-color: #f8d7da;
+    color: #721c24;
+    padding: 1rem;
+    border: 1px solid #f5c6cb;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
 /* Upload Progress Overlay Styles */
 .upload-overlay {
     position: fixed;

--- a/web/index.html
+++ b/web/index.html
@@ -76,6 +76,14 @@
 
     <script type="module" src="js/main.js"></script>
 
+    <!-- Settings Button FAB -->
+    <button id="settingsButton" class="settings-btn" aria-label="Open settings">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 15.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z"/>
+        </svg>
+    </button>
+
     <!-- Upload Button FAB -->
     <button id="uploadButton" class="upload-btn" aria-label="Upload files">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
@@ -84,5 +92,39 @@
         </svg>
     </button>
     <input type="file" id="fileInput" multiple style="display: none;">
+
+    <!-- Settings Overlay -->
+    <div id="settingsOverlay" class="settings-overlay" style="display: none;">
+        <div class="settings-dialog">
+            <h2>Settings</h2>
+            <div id="settingsError" class="settings-error" style="display: none;"></div>
+            <form id="settingsForm">
+                <label for="rescanInterval">Rescan Interval (seconds):</label>
+                <input type="number" id="rescanInterval" name="rescan_interval" min="0">
+
+                <label for="taggingModel">Tagging Model:</label>
+                <select id="taggingModel" name="tagging_model">
+                    <option value="Off">Off</option>
+                    <option value="Resnet">Resnet</option>
+                    <option value="Mobilenet">Mobilenet</option>
+                </select>
+
+                <label for="archivalBackend">Archival Backend:</label>
+                <select id="archivalBackend" name="archival_backend">
+                    <option value="Off">Off</option>
+                    <option value="Google Cloud">Google Cloud</option>
+                    <option value="AWS">AWS</option>
+                </select>
+
+                <label for="archivalBucket">Archival Bucket:</label>
+                <input type="text" id="archivalBucket" name="archival_bucket">
+
+                <div class="settings-actions">
+                    <button type="button" id="cancelSettings">Cancel</button>
+                    <button type="submit" id="saveSettings">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
 </body>
 </html>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -548,12 +548,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const archivalBucket = document.getElementById('archivalBucket');
 
     function validateSettings() {
-        const isArchivalOn = archivalBackend.value !== 'Off';
-        const isBucketEmpty = archivalBucket.value.trim() === '';
-        saveSettingsButton.disabled = isArchivalOn && isBucketEmpty;
+        if (saveSettingsButton && archivalBackend && archivalBucket) {
+            const isArchivalOn = archivalBackend.value !== 'Off';
+            const isBucketEmpty = archivalBucket.value.trim() === '';
+            saveSettingsButton.disabled = isArchivalOn && isBucketEmpty;
+        }
     }
 
-    if (settingsButton && settingsOverlay && settingsForm && cancelSettingsButton) {
+    if (settingsButton && settingsOverlay && settingsForm && cancelSettingsButton && saveSettingsButton) {
         if (archivalBackend && archivalBucket) {
             archivalBackend.addEventListener('change', validateSettings);
             archivalBucket.addEventListener('input', validateSettings);

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -543,8 +543,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const settingsForm = document.getElementById('settingsForm');
     const cancelSettingsButton = document.getElementById('cancelSettings');
     const settingsError = document.getElementById('settingsError');
+    const saveSettingsButton = document.getElementById('saveSettings');
+    const archivalBackend = document.getElementById('archivalBackend');
+    const archivalBucket = document.getElementById('archivalBucket');
+
+    function validateSettings() {
+        const isArchivalOn = archivalBackend.value !== 'Off';
+        const isBucketEmpty = archivalBucket.value.trim() === '';
+        saveSettingsButton.disabled = isArchivalOn && isBucketEmpty;
+    }
 
     if (settingsButton && settingsOverlay && settingsForm && cancelSettingsButton) {
+        if (archivalBackend && archivalBucket) {
+            archivalBackend.addEventListener('change', validateSettings);
+            archivalBucket.addEventListener('input', validateSettings);
+        }
+
         settingsButton.addEventListener('click', async () => {
             try {
                 const response = await fetch('/api/settings');
@@ -554,8 +568,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 const settings = await response.json();
                 document.getElementById('rescanInterval').value = settings.rescan_interval;
                 document.getElementById('taggingModel').value = settings.tagging_model;
-                document.getElementById('archivalBackend').value = settings.archival_backend;
-                document.getElementById('archivalBucket').value = settings.archival_bucket;
+                archivalBackend.value = settings.archival_backend;
+                archivalBucket.value = settings.archival_bucket;
+                validateSettings(); // Initial validation
                 settingsOverlay.style.display = 'flex';
             } catch (error) {
                 console.error('Error fetching settings:', error);


### PR DESCRIPTION
This commit introduces a new settings UI that allows you to edit application settings from the web interface.

- Adds a settings floating action button (FAB) to the main page.
- Clicking the FAB opens an overlay with a form for editing settings.
- The form is pre-populated with the current settings from the backend.
- You can save your changes, which are persisted to the backend, or cancel to discard them.
- The UI provides feedback on whether the save operation was successful.