### PR TITLE
Store tagging model in database and regenerate tags on model change

### DIFF
--- a/media_server/database.py
+++ b/media_server/database.py
@@ -8,6 +8,7 @@ DATABASE_NAME = "media_cache.sqlite3"
 # Use a thread-local storage for database connections
 thread_local = threading.local()
 
+
 def get_db_path(storage_dir: Optional[str] = None) -> str:
     """
     Constructs the absolute path to the SQLite database file.
@@ -28,9 +29,14 @@ def get_db_path(storage_dir: Optional[str] = None) -> str:
         # from the application's configuration.
         # Trying to infer from a common location if not provided.
         # This might need adjustment based on how server.py sets it up.
-        if hasattr(thread_local, 'db_path_for_current_thread') and thread_local.db_path_for_current_thread: # Check specific attribute
+        if (
+            hasattr(thread_local, "db_path_for_current_thread")
+            and thread_local.db_path_for_current_thread
+        ):  # Check specific attribute
             return thread_local.db_path_for_current_thread
-        logging.warning("storage_dir not provided to get_db_path, trying to use current dir for DB.")
+        logging.warning(
+            "storage_dir not provided to get_db_path, trying to use current dir for DB."
+        )
         # Fallback to a generic name if no storage_dir and no thread-local path available
         # This situation should be rare in a configured application
         return os.path.join(os.getcwd(), DATABASE_NAME)
@@ -54,15 +60,21 @@ def get_db_connection(db_path: str) -> sqlite3.Connection:
         A sqlite3.Connection object for the current thread.
     """
     # Check if the current thread already has a connection, and if it's for the same db_path
-    if not hasattr(thread_local, 'connection') or \
-       not hasattr(thread_local, 'db_path_for_current_thread') or \
-       thread_local.db_path_for_current_thread != db_path:
+    if (
+        not hasattr(thread_local, "connection")
+        or not hasattr(thread_local, "db_path_for_current_thread")
+        or thread_local.db_path_for_current_thread != db_path
+    ):
 
-        logging.info(f"Creating new SQLite connection for thread {threading.get_ident()} to {db_path}")
+        logging.info(
+            f"Creating new SQLite connection for thread {threading.get_ident()} to {db_path}"
+        )
         # Ensure the directory for the database exists before connecting
         db_dir = os.path.dirname(db_path)
-        if db_dir: # Check if db_dir is not empty (i.e., not just a filename in current dir)
-             os.makedirs(db_dir, exist_ok=True)
+        if (
+            db_dir
+        ):  # Check if db_dir is not empty (i.e., not just a filename in current dir)
+            os.makedirs(db_dir, exist_ok=True)
 
         # Using check_same_thread=False can be risky if connections are shared across threads
         # without external serialization. However, thread_local aims to give each thread its own connection.
@@ -72,9 +84,12 @@ def get_db_connection(db_path: str) -> sqlite3.Connection:
         # If a conn object from thread_local is passed to another thread, issues can occur.
         # Sticking to `check_same_thread=False` as per original plan, but with caution.
         thread_local.connection = sqlite3.connect(db_path, check_same_thread=False)
-        thread_local.connection.row_factory = sqlite3.Row # Access columns by name
-        thread_local.db_path_for_current_thread = db_path # Store the path for which this connection was made
+        thread_local.connection.row_factory = sqlite3.Row  # Access columns by name
+        thread_local.db_path_for_current_thread = (
+            db_path  # Store the path for which this connection was made
+        )
     return thread_local.connection
+
 
 def close_db_connection() -> None:
     """
@@ -83,12 +98,15 @@ def close_db_connection() -> None:
     If a connection exists in the thread-local storage, this function will
     close it and remove the connection attributes from the storage.
     """
-    if hasattr(thread_local, 'connection'):
-        logging.info(f"Closing SQLite connection for thread {threading.get_ident()} from {getattr(thread_local, 'db_path_for_current_thread', 'N/A')}")
+    if hasattr(thread_local, "connection"):
+        logging.info(
+            f"Closing SQLite connection for thread {threading.get_ident()} from {getattr(thread_local, 'db_path_for_current_thread', 'N/A')}"
+        )
         thread_local.connection.close()
         del thread_local.connection
-        if hasattr(thread_local, 'db_path_for_current_thread'):
+        if hasattr(thread_local, "db_path_for_current_thread"):
             del thread_local.db_path_for_current_thread
+
 
 def init_db(storage_dir: str) -> None:
     """
@@ -105,11 +123,11 @@ def init_db(storage_dir: str) -> None:
     # It should not rely on a pre-existing flask_g or shared thread_local connection from elsewhere
     # for its setup task, as it might run before any requests or other threads have started.
 
-    db_path = get_db_path(storage_dir) # Use storage_dir to get the correct path
+    db_path = get_db_path(storage_dir)  # Use storage_dir to get the correct path
 
     # Ensure the directory for the database exists
     db_dir = os.path.dirname(db_path)
-    if db_dir: # If db_path includes a directory part
+    if db_dir:  # If db_path includes a directory part
         os.makedirs(db_dir, exist_ok=True)
 
     # Use a temporary connection for init, not necessarily the thread_local one,
@@ -120,7 +138,8 @@ def init_db(storage_dir: str) -> None:
     try:
         with conn:
             cursor = conn.cursor()
-            cursor.execute("""
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS media_files (
                     sha256_hex TEXT PRIMARY KEY,
                     filename TEXT NOT NULL,
@@ -140,10 +159,17 @@ def init_db(storage_dir: str) -> None:
                     tags TEXT,
                     tagging_model TEXT
                 )
-            """)
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_path ON media_files (file_path)")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_last_modified ON media_files (last_modified)")
-            logging.info(f"Database initialized and media_files table ensured at {db_path}")
+            """
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_file_path ON media_files (file_path)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_last_modified ON media_files (last_modified)"
+            )
+            logging.info(
+                f"Database initialized and media_files table ensured at {db_path}"
+            )
     except sqlite3.Error as e:
         logging.error(f"Error initializing database at {db_path}: {e}")
         raise
@@ -164,35 +190,62 @@ def add_or_update_media_file(db_path: str, media_data: Dict[str, Any]) -> None:
         media_data: A dictionary containing the media file's metadata.
     """
     conn = get_db_connection(db_path)
-    required_fields = ['sha256_hex', 'filename', 'file_path', 'last_modified']
+    required_fields = ["sha256_hex", "filename", "file_path", "last_modified"]
     for field in required_fields:
         if field not in media_data or media_data[field] is None:
-            logging.error(f"Required field {field} missing or None in media_data for add_or_update. Data: {media_data}")
+            logging.error(
+                f"Required field {field} missing or None in media_data for add_or_update. Data: {media_data}"
+            )
             raise ValueError(f"Required field {field} missing or None in media_data")
     try:
         with conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT sha256_hex FROM media_files WHERE file_path = ? AND sha256_hex != ?",
-                           (media_data['file_path'], media_data['sha256_hex']))
+            cursor.execute(
+                "SELECT sha256_hex FROM media_files WHERE file_path = ? AND sha256_hex != ?",
+                (media_data["file_path"], media_data["sha256_hex"]),
+            )
             existing_sha_for_path = cursor.fetchone()
             if existing_sha_for_path:
-                logging.warning(f"File path {media_data['file_path']} was previously associated with SHA {existing_sha_for_path[0]}. Deleting old entry.")
-                conn.execute("DELETE FROM media_files WHERE sha256_hex = ?", (existing_sha_for_path[0],))
+                logging.warning(
+                    f"File path {media_data['file_path']} was previously associated with SHA {existing_sha_for_path[0]}. Deleting old entry."
+                )
+                conn.execute(
+                    "DELETE FROM media_files WHERE sha256_hex = ?",
+                    (existing_sha_for_path[0],),
+                )
             columns = [
-                'sha256_hex', 'filename', 'original_filename', 'file_path',
-                'last_modified', 'original_creation_date', 'thumbnail_file',
-                'width', 'height', 'latitude', 'longitude', 'city', 'country',
-                'mime_type', 'filesize', 'tags', 'tagging_model'
+                "sha256_hex",
+                "filename",
+                "original_filename",
+                "file_path",
+                "last_modified",
+                "original_creation_date",
+                "thumbnail_file",
+                "width",
+                "height",
+                "latitude",
+                "longitude",
+                "city",
+                "country",
+                "mime_type",
+                "filesize",
+                "tags",
+                "tagging_model",
             ]
             values = [media_data.get(col) for col in columns]
             sql = f"INSERT OR REPLACE INTO media_files ({', '.join(columns)}) VALUES ({', '.join(['?'] * len(columns))})"
             conn.execute(sql, values)
     except sqlite3.IntegrityError as e:
-        logging.error(f"Integrity error adding/updating media file {media_data.get('file_path')} (SHA: {media_data.get('sha256_hex')}): {e}")
+        logging.error(
+            f"Integrity error adding/updating media file {media_data.get('file_path')} (SHA: {media_data.get('sha256_hex')}): {e}"
+        )
         raise
     except sqlite3.Error as e:
-        logging.error(f"Database error adding/updating media file {media_data.get('file_path')}: {e}")
+        logging.error(
+            f"Database error adding/updating media file {media_data.get('file_path')}: {e}"
+        )
         raise
+
 
 def get_media_file_by_sha(db_path: str, sha256_hex: str) -> Optional[Dict[str, Any]]:
     """
@@ -215,6 +268,7 @@ def get_media_file_by_sha(db_path: str, sha256_hex: str) -> Optional[Dict[str, A
         logging.error(f"Database error retrieving media file by SHA {sha256_hex}: {e}")
         return None
 
+
 def get_media_file_by_path(db_path: str, file_path: str) -> Optional[Dict[str, Any]]:
     """
     Retrieves a media file's metadata from the database by its file path.
@@ -236,6 +290,7 @@ def get_media_file_by_path(db_path: str, file_path: str) -> Optional[Dict[str, A
         logging.error(f"Database error retrieving media file by path {file_path}: {e}")
         return None
 
+
 def get_all_media_files(db_path: str) -> Dict[str, Dict[str, Any]]:
     """
     Retrieves all media file records from the database.
@@ -250,13 +305,16 @@ def get_all_media_files(db_path: str) -> Dict[str, Dict[str, Any]]:
     media_dict = {}
     try:
         cursor = conn.cursor()
-        cursor.execute("SELECT * FROM media_files ORDER BY original_creation_date DESC, filename ASC")
+        cursor.execute(
+            "SELECT * FROM media_files ORDER BY original_creation_date DESC, filename ASC"
+        )
         for row in cursor.fetchall():
-            media_dict[row['sha256_hex']] = dict(row)
+            media_dict[row["sha256_hex"]] = dict(row)
         return media_dict
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving all media files: {e}")
         return {}
+
 
 def get_all_file_paths_and_last_modified(db_path: str) -> Dict[str, float]:
     """
@@ -274,11 +332,14 @@ def get_all_file_paths_and_last_modified(db_path: str) -> Dict[str, float]:
         cursor = conn.cursor()
         cursor.execute("SELECT file_path, last_modified FROM media_files")
         for row in cursor.fetchall():
-            paths[row['file_path']] = row['last_modified']
+            paths[row["file_path"]] = row["last_modified"]
         return paths
     except sqlite3.Error as e:
-        logging.error(f"Database error retrieving file paths and last modified times: {e}")
+        logging.error(
+            f"Database error retrieving file paths and last modified times: {e}"
+        )
         return {}
+
 
 def delete_media_file_by_sha(db_path: str, sha256_hex: str) -> bool:
     """
@@ -295,11 +356,14 @@ def delete_media_file_by_sha(db_path: str, sha256_hex: str) -> bool:
     try:
         with conn:
             cursor = conn.cursor()
-            cursor.execute("DELETE FROM media_files WHERE sha256_hex = ?", (sha256_hex,))
+            cursor.execute(
+                "DELETE FROM media_files WHERE sha256_hex = ?", (sha256_hex,)
+            )
             return cursor.rowcount > 0
     except sqlite3.Error as e:
         logging.error(f"Database error deleting media file by SHA {sha256_hex}: {e}")
         return False
+
 
 def delete_media_file_by_path(db_path: str, file_path: str) -> bool:
     """
@@ -322,6 +386,7 @@ def delete_media_file_by_path(db_path: str, file_path: str) -> bool:
         logging.error(f"Database error deleting media file by path {file_path}: {e}")
         return False
 
+
 def get_file_last_modified(db_path: str, file_path: str) -> Optional[float]:
     """
     Retrieves the last modified timestamp for a specific file path.
@@ -336,12 +401,17 @@ def get_file_last_modified(db_path: str, file_path: str) -> Optional[float]:
     conn = get_db_connection(db_path)
     try:
         cursor = conn.cursor()
-        cursor.execute("SELECT last_modified FROM media_files WHERE file_path = ?", (file_path,))
+        cursor.execute(
+            "SELECT last_modified FROM media_files WHERE file_path = ?", (file_path,)
+        )
         row = cursor.fetchone()
-        return row['last_modified'] if row else None
+        return row["last_modified"] if row else None
     except sqlite3.Error as e:
-        logging.error(f"Database error retrieving last_modified for path {file_path}: {e}")
+        logging.error(
+            f"Database error retrieving last_modified for path {file_path}: {e}"
+        )
         return None
+
 
 def get_all_db_file_paths(db_path: str) -> List[str]:
     """
@@ -359,11 +429,12 @@ def get_all_db_file_paths(db_path: str) -> List[str]:
         cursor = conn.cursor()
         cursor.execute("SELECT file_path FROM media_files")
         for row in cursor.fetchall():
-            paths.append(row['file_path'])
+            paths.append(row["file_path"])
         return paths
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving all file paths: {e}")
         return []
+
 
 def get_all_shas_and_thumbnails(db_path: str) -> Dict[str, Optional[str]]:
     """
@@ -381,13 +452,16 @@ def get_all_shas_and_thumbnails(db_path: str) -> Dict[str, Optional[str]]:
         cursor = conn.cursor()
         cursor.execute("SELECT sha256_hex, thumbnail_file FROM media_files")
         for row in cursor.fetchall():
-            shas_and_thumbnails[row['sha256_hex']] = row['thumbnail_file']
+            shas_and_thumbnails[row["sha256_hex"]] = row["thumbnail_file"]
         return shas_and_thumbnails
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving SHAs and thumbnail paths: {e}")
         return {}
 
-def update_media_file_fields(db_path: str, sha256_hex: str, fields_to_update: Dict[str, Any]) -> bool:
+
+def update_media_file_fields(
+    db_path: str, sha256_hex: str, fields_to_update: Dict[str, Any]
+) -> bool:
     """
     Updates specific fields for a media file record in the database.
 
@@ -403,10 +477,22 @@ def update_media_file_fields(db_path: str, sha256_hex: str, fields_to_update: Di
         return False
     conn = get_db_connection(db_path)
     valid_columns = [
-        'filename', 'original_filename', 'file_path', 'last_modified',
-        'original_creation_date', 'thumbnail_file', 'width', 'height',
-        'latitude', 'longitude', 'city', 'country', 'mime_type', 'filesize', 'tags',
-        'tagging_model'
+        "filename",
+        "original_filename",
+        "file_path",
+        "last_modified",
+        "original_creation_date",
+        "thumbnail_file",
+        "width",
+        "height",
+        "latitude",
+        "longitude",
+        "city",
+        "country",
+        "mime_type",
+        "filesize",
+        "tags",
+        "tagging_model",
     ]
     update_clauses = []
     update_values = []
@@ -422,10 +508,16 @@ def update_media_file_fields(db_path: str, sha256_hex: str, fields_to_update: Di
         with conn:
             cursor = conn.cursor()
             cursor.execute(sql, tuple(update_values))
-            return cursor.rowcount > 0 or (cursor.execute("SELECT 1 FROM media_files WHERE sha256_hex = ?", (sha256_hex,)).fetchone() is not None)
+            return cursor.rowcount > 0 or (
+                cursor.execute(
+                    "SELECT 1 FROM media_files WHERE sha256_hex = ?", (sha256_hex,)
+                ).fetchone()
+                is not None
+            )
     except sqlite3.Error as e:
         logging.error(f"Database error updating fields for SHA {sha256_hex}: {e}")
         return False
+
 
 def get_all_shas_in_db(db_path: str) -> List[str]:
     """
@@ -443,11 +535,12 @@ def get_all_shas_in_db(db_path: str) -> List[str]:
         cursor = conn.cursor()
         cursor.execute("SELECT sha256_hex FROM media_files")
         for row in cursor.fetchall():
-            shas.append(row['sha256_hex'])
+            shas.append(row["sha256_hex"])
         return shas
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving all SHAs: {e}")
         return []
+
 
 def get_media_files_by_date(db_path: str, date: float) -> Dict[str, Dict[str, Any]]:
     """
@@ -465,15 +558,21 @@ def get_media_files_by_date(db_path: str, date: float) -> Dict[str, Dict[str, An
     try:
         cursor = conn.cursor()
         # Compare the date part of the timestamp
-        cursor.execute("SELECT * FROM media_files WHERE date(original_creation_date, 'unixepoch') = date(?, 'unixepoch')", (date,))
+        cursor.execute(
+            "SELECT * FROM media_files WHERE date(original_creation_date, 'unixepoch') = date(?, 'unixepoch')",
+            (date,),
+        )
         for row in cursor.fetchall():
-            media_dict[row['sha256_hex']] = dict(row)
+            media_dict[row["sha256_hex"]] = dict(row)
         return media_dict
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving media files by date: {e}")
         return {}
 
-def get_media_files_by_date_range(db_path: str, start_date: float, end_date: float) -> Dict[str, Dict[str, Any]]:
+
+def get_media_files_by_date_range(
+    db_path: str, start_date: float, end_date: float
+) -> Dict[str, Dict[str, Any]]:
     """
     Retrieves media files created within a specific date range.
 
@@ -489,15 +588,21 @@ def get_media_files_by_date_range(db_path: str, start_date: float, end_date: flo
     media_dict = {}
     try:
         cursor = conn.cursor()
-        cursor.execute("SELECT * FROM media_files WHERE original_creation_date BETWEEN ? AND ?", (start_date, end_date))
+        cursor.execute(
+            "SELECT * FROM media_files WHERE original_creation_date BETWEEN ? AND ?",
+            (start_date, end_date),
+        )
         for row in cursor.fetchall():
-            media_dict[row['sha256_hex']] = dict(row)
+            media_dict[row["sha256_hex"]] = dict(row)
         return media_dict
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving media files by date range: {e}")
         return {}
 
-def get_media_files_by_location(db_path: str, city: str, country: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
+
+def get_media_files_by_location(
+    db_path: str, city: str, country: Optional[str] = None
+) -> Dict[str, Dict[str, Any]]:
     """
     Retrieves media files from a specific location.
 
@@ -514,11 +619,16 @@ def get_media_files_by_location(db_path: str, city: str, country: Optional[str] 
     try:
         cursor = conn.cursor()
         if country:
-            cursor.execute("SELECT * FROM media_files WHERE LOWER(city) = LOWER(?) AND LOWER(country) = LOWER(?)", (city, country))
+            cursor.execute(
+                "SELECT * FROM media_files WHERE LOWER(city) = LOWER(?) AND LOWER(country) = LOWER(?)",
+                (city, country),
+            )
         else:
-            cursor.execute("SELECT * FROM media_files WHERE LOWER(city) = LOWER(?)", (city,))
+            cursor.execute(
+                "SELECT * FROM media_files WHERE LOWER(city) = LOWER(?)", (city,)
+            )
         for row in cursor.fetchall():
-            media_dict[row['sha256_hex']] = dict(row)
+            media_dict[row["sha256_hex"]] = dict(row)
         return media_dict
     except sqlite3.Error as e:
         logging.error(f"Database error retrieving media files by location: {e}")

--- a/media_server/database.py
+++ b/media_server/database.py
@@ -137,7 +137,8 @@ def init_db(storage_dir: str) -> None:
                     country TEXT,
                     mime_type TEXT,
                     filesize INTEGER,
-                    tags TEXT
+                    tags TEXT,
+                    tagging_model TEXT
                 )
             """)
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_file_path ON media_files (file_path)")
@@ -181,7 +182,7 @@ def add_or_update_media_file(db_path: str, media_data: Dict[str, Any]) -> None:
                 'sha256_hex', 'filename', 'original_filename', 'file_path',
                 'last_modified', 'original_creation_date', 'thumbnail_file',
                 'width', 'height', 'latitude', 'longitude', 'city', 'country',
-                'mime_type', 'filesize', 'tags'
+                'mime_type', 'filesize', 'tags', 'tagging_model'
             ]
             values = [media_data.get(col) for col in columns]
             sql = f"INSERT OR REPLACE INTO media_files ({', '.join(columns)}) VALUES ({', '.join(['?'] * len(columns))})"
@@ -404,7 +405,8 @@ def update_media_file_fields(db_path: str, sha256_hex: str, fields_to_update: Di
     valid_columns = [
         'filename', 'original_filename', 'file_path', 'last_modified',
         'original_creation_date', 'thumbnail_file', 'width', 'height',
-        'latitude', 'longitude', 'city', 'country', 'mime_type', 'filesize', 'tags'
+        'latitude', 'longitude', 'city', 'country', 'mime_type', 'filesize', 'tags',
+        'tagging_model'
     ]
     update_clauses = []
     update_values = []

--- a/media_server/geolocator.py
+++ b/media_server/geolocator.py
@@ -3,12 +3,14 @@ from dataclasses import dataclass
 from math import radians, sin, cos, sqrt, atan2
 from threading import Lock
 
+
 @dataclass
 class City:
     name: str
     country: str
     latitude: float
     longitude: float
+
 
 class GeoLocator:
     """
@@ -18,6 +20,7 @@ class GeoLocator:
     to find the closest city to a given latitude and longitude. It uses the
         Haversine formula to calculate distances.
     """
+
     _instance = None
     _lock = Lock()
 
@@ -55,7 +58,7 @@ class GeoLocator:
         with self._lock:
             if self.loaded:
                 return
-            with open(csv_file, 'r') as f:
+            with open(csv_file, "r") as f:
                 reader = csv.reader(f)
                 next(reader)  # Skip header
                 for row in reader:
@@ -84,11 +87,13 @@ class GeoLocator:
         if not self.cities:
             return None
 
-        min_distance = float('inf')
+        min_distance = float("inf")
         closest_city = None
 
         for city in self.cities:
-            distance = self._haversine_distance(latitude, longitude, city.latitude, city.longitude)
+            distance = self._haversine_distance(
+                latitude, longitude, city.latitude, city.longitude
+            )
             if distance < min_distance:
                 min_distance = distance
                 closest_city = city

--- a/media_server/image_classifier.py
+++ b/media_server/image_classifier.py
@@ -1,14 +1,22 @@
 import os
-os.environ['KERAS_BACKEND'] = 'torch'
+
+os.environ["KERAS_BACKEND"] = "torch"
 
 import keras
 from keras.applications import ResNet50V2, MobileNetV3Small
 from keras.preprocessing import image
-from keras.applications.resnet_v2 import preprocess_input as resnet_preprocess, decode_predictions as resnet_decode
-from keras.applications.mobilenet_v3 import preprocess_input as mobilenet_preprocess, decode_predictions as mobilenet_decode
+from keras.applications.resnet_v2 import (
+    preprocess_input as resnet_preprocess,
+    decode_predictions as resnet_decode,
+)
+from keras.applications.mobilenet_v3 import (
+    preprocess_input as mobilenet_preprocess,
+    decode_predictions as mobilenet_decode,
+)
 import numpy as np
 
 from media_server.settings import Settings
+
 
 class ImageClassifier:
     def __init__(self, settings: Settings):
@@ -18,11 +26,11 @@ class ImageClassifier:
         self.decode_predictions = None
 
         if self.settings.tagging_model == "Resnet":
-            self.model = ResNet50V2(weights='imagenet')
+            self.model = ResNet50V2(weights="imagenet")
             self.preprocess_input = resnet_preprocess
             self.decode_predictions = resnet_decode
         elif self.settings.tagging_model == "Mobilenet":
-            self.model = MobileNetV3Small(weights='imagenet')
+            self.model = MobileNetV3Small(weights="imagenet")
             self.preprocess_input = mobilenet_preprocess
             self.decode_predictions = mobilenet_decode
 

--- a/media_server/media_scanner.py
+++ b/media_server/media_scanner.py
@@ -8,12 +8,14 @@ from datetime import datetime
 from pillow_heif import register_heif_opener
 
 try:
-    from . import database as db_utils # Relative import for package
+    from . import database as db_utils  # Relative import for package
     from .geolocator import GeoLocator
     from .image_classifier import ImageClassifier
     from .settings import SettingsManager
 except ImportError:
-    from media_server import database as db_utils # Fallback for direct execution/testing
+    from media_server import (
+        database as db_utils,
+    )  # Fallback for direct execution/testing
     from media_server.geolocator import GeoLocator
     from media_server.image_classifier import ImageClassifier
     from media_server.settings import SettingsManager
@@ -44,6 +46,7 @@ def _convert_dms_to_decimal(dms_tuple: Tuple[float, ...], ref: str) -> Optional[
         return None
 
     try:
+
         def to_float(val):
             if isinstance(val, tuple) and len(val) == 2:
                 return float(val[0]) / float(val[1])
@@ -58,15 +61,17 @@ def _convert_dms_to_decimal(dms_tuple: Tuple[float, ...], ref: str) -> Optional[
 
     decimal_degrees = degrees_val + (minutes_val / 60.0) + (seconds_val / 3600.0)
 
-    if ref in ['S', 'W']:
+    if ref in ["S", "W"]:
         decimal_degrees = -decimal_degrees
-    elif ref not in ['N', 'E']:
+    elif ref not in ["N", "E"]:
         logging.warning(f"Invalid GPS reference: {ref}")
         return None
     return decimal_degrees
 
 
-def _get_gps_coordinates_from_exif(exif_data: dict) -> Tuple[Optional[float], Optional[float]]:
+def _get_gps_coordinates_from_exif(
+    exif_data: dict,
+) -> Tuple[Optional[float], Optional[float]]:
     """Extracts GPS latitude and longitude from EXIF data."""
     latitude = None
     longitude = None
@@ -103,6 +108,7 @@ THUMBNAIL_DIR_NAME = ".thumbnails"
 THUMBNAIL_SIZE = (256, 256)
 THUMBNAIL_EXTENSION = ".png"
 
+
 def get_file_sha256(file_path: str) -> Optional[str]:
     """
     Computes the SHA256 hash of a file.
@@ -124,6 +130,7 @@ def get_file_sha256(file_path: str) -> Optional[str]:
         logging.error(f"Could not read file for hashing: {file_path}")
         return None
 
+
 def is_media_file(file_path: str) -> bool:
     """
     Determines if a file is a media file based on its MIME type.
@@ -136,13 +143,16 @@ def is_media_file(file_path: str) -> bool:
     """
     mime_type, _ = mimetypes.guess_type(file_path)
     if mime_type:
-        return mime_type.startswith('image/') or mime_type.startswith('video/')
+        return mime_type.startswith("image/") or mime_type.startswith("video/")
     return False
 
-def generate_thumbnail(source_image_path: str,
-                       thumbnail_dir: str, # Absolute path to .thumbnails directory
-                       sha256_hex: str,
-                       target_size: Tuple[int, int] = THUMBNAIL_SIZE) -> Optional[str]:
+
+def generate_thumbnail(
+    source_image_path: str,
+    thumbnail_dir: str,  # Absolute path to .thumbnails directory
+    sha256_hex: str,
+    target_size: Tuple[int, int] = THUMBNAIL_SIZE,
+) -> Optional[str]:
     """
     Generates a thumbnail for a given image file.
 
@@ -169,9 +179,13 @@ def generate_thumbnail(source_image_path: str,
 
     thumbnail_filename_only = sha256_hex + THUMBNAIL_EXTENSION
     # thumbnail_path_absolute is the full absolute path for saving: e.g. /path/to/storage/.thumbnails/ab/hash.png
-    thumbnail_path_absolute = os.path.join(thumbnail_subdir_abs, thumbnail_filename_only)
+    thumbnail_path_absolute = os.path.join(
+        thumbnail_subdir_abs, thumbnail_filename_only
+    )
     # Path to be returned and stored in DB should be relative to thumbnail_dir: e.g. 'ab/hash.png'
-    thumbnail_path_relative_to_basedir = os.path.join(sha256_prefix, thumbnail_filename_only)
+    thumbnail_path_relative_to_basedir = os.path.join(
+        sha256_prefix, thumbnail_filename_only
+    )
 
     if os.path.exists(thumbnail_path_absolute):
         logging.debug(f"Thumbnail already exists: {thumbnail_path_absolute}")
@@ -185,16 +199,22 @@ def generate_thumbnail(source_image_path: str,
             paste_y = (target_size[1] - img.height) // 2
             final_thumb.paste(img, (paste_x, paste_y))
             final_thumb.save(thumbnail_path_absolute, "PNG")
-            logging.info(f"Generated thumbnail: {thumbnail_path_absolute} for {source_image_path}")
+            logging.info(
+                f"Generated thumbnail: {thumbnail_path_absolute} for {source_image_path}"
+            )
             return thumbnail_path_relative_to_basedir
     except FileNotFoundError:
-        logging.error(f"Source image not found for thumbnail generation: {source_image_path}")
+        logging.error(
+            f"Source image not found for thumbnail generation: {source_image_path}"
+        )
     except Exception as e:
         logging.error(f"Failed to generate thumbnail for {source_image_path}: {e}")
     return None
 
 
-def _delete_thumbnail_file(thumbnail_dir_abs: str, thumbnail_relative_path: Optional[str]):
+def _delete_thumbnail_file(
+    thumbnail_dir_abs: str, thumbnail_relative_path: Optional[str]
+):
     """Deletes a thumbnail file given its relative path and the absolute thumbnail base directory."""
     if not thumbnail_relative_path:
         return
@@ -217,10 +237,12 @@ def _delete_thumbnail_file(thumbnail_dir_abs: str, thumbnail_relative_path: Opti
         # If the path was just 'hash.ext', it might be an old flat thumbnail.
         # This case is less likely if generate_thumbnail always returns prefix/hash.ext
         # but could be relevant if old data exists or if thumbnail_relative_path is just filename.
-        if not os.path.dirname(thumbnail_relative_path): # It's a flat filename
-             # This means thumb_to_delete_abs was already correct for a flat structure.
-             # No need for further action if it didn't exist.
-             logging.debug(f"Thumbnail {thumb_to_delete_abs} (potentially flat) not found for deletion.")
+        if not os.path.dirname(thumbnail_relative_path):  # It's a flat filename
+            # This means thumb_to_delete_abs was already correct for a flat structure.
+            # No need for further action if it didn't exist.
+            logging.debug(
+                f"Thumbnail {thumb_to_delete_abs} (potentially flat) not found for deletion."
+            )
 
 
 def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None:
@@ -252,82 +274,144 @@ def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None
     image_classifier = ImageClassifier(settings)
 
     geolocator = GeoLocator()
-    cities_csv_path = os.path.join(os.path.dirname(__file__), 'resources', 'cities.csv')
+    cities_csv_path = os.path.join(os.path.dirname(__file__), "resources", "cities.csv")
     geolocator.load_cities(cities_csv_path)
 
     abs_storage_dir = os.path.abspath(storage_dir)
-    processed_rel_file_paths: Set[str] = set() # Keep track of files processed in this scan run
+    processed_rel_file_paths: Set[str] = (
+        set()
+    )  # Keep track of files processed in this scan run
 
     # Phase 1: Handle existing files in DB during a rescan
     if rescan:
         logging.info(f"Rescanning directory: {storage_dir} using DB: {db_path}")
-        db_file_entries = db_utils.get_all_media_files(db_path) # Get all entries: {sha: data}
+        db_file_entries = db_utils.get_all_media_files(
+            db_path
+        )  # Get all entries: {sha: data}
 
         for sha256_hex, db_entry in db_file_entries.items():
-            rel_file_path = db_entry.get('file_path')
+            rel_file_path = db_entry.get("file_path")
             if not rel_file_path:
-                logging.warning(f"DB entry for SHA {sha256_hex} is missing file_path. Skipping.")
+                logging.warning(
+                    f"DB entry for SHA {sha256_hex} is missing file_path. Skipping."
+                )
                 continue
 
-            abs_file_path_to_check = os.path.normpath(os.path.join(abs_storage_dir, rel_file_path))
-            processed_rel_file_paths.add(rel_file_path) # Mark as seen from DB perspective
+            abs_file_path_to_check = os.path.normpath(
+                os.path.join(abs_storage_dir, rel_file_path)
+            )
+            processed_rel_file_paths.add(
+                rel_file_path
+            )  # Mark as seen from DB perspective
 
             if not os.path.isfile(abs_file_path_to_check):
-                logging.info(f"File for SHA {sha256_hex} (path: {rel_file_path}) no longer exists. Removing from DB.")
-                _delete_thumbnail_file(thumbnail_dir_abs, db_entry.get('thumbnail_file'))
+                logging.info(
+                    f"File for SHA {sha256_hex} (path: {rel_file_path}) no longer exists. Removing from DB."
+                )
+                _delete_thumbnail_file(
+                    thumbnail_dir_abs, db_entry.get("thumbnail_file")
+                )
                 db_utils.delete_media_file_by_sha(db_path, sha256_hex)
                 continue
 
             try:
                 current_fs_last_modified = os.path.getmtime(abs_file_path_to_check)
-                db_last_modified = db_entry.get('last_modified')
+                db_last_modified = db_entry.get("last_modified")
 
-                if abs(current_fs_last_modified - db_last_modified) > 1e-6 or \
-                   (db_entry.get('tagging_model') != settings.tagging_model and settings.tagging_model != 'Off'): # Compare floats carefully
-                    logging.info(f"File {rel_file_path} (SHA: {sha256_hex}) has been modified. Re-processing.")
+                if abs(current_fs_last_modified - db_last_modified) > 1e-6 or (
+                    db_entry.get("tagging_model") != settings.tagging_model
+                    and settings.tagging_model != "Off"
+                ):  # Compare floats carefully
+                    logging.info(
+                        f"File {rel_file_path} (SHA: {sha256_hex}) has been modified. Re-processing."
+                    )
                     # File content might have changed, leading to a new SHA, or just metadata like mtime.
                     new_sha256_hex = get_file_sha256(abs_file_path_to_check)
 
-                    if not new_sha256_hex: # Error hashing, treat as problematic
-                        logging.error(f"Could not re-hash modified file {rel_file_path}. Removing old DB entry.")
-                        _delete_thumbnail_file(thumbnail_dir_abs, db_entry.get('thumbnail_file'))
+                    if not new_sha256_hex:  # Error hashing, treat as problematic
+                        logging.error(
+                            f"Could not re-hash modified file {rel_file_path}. Removing old DB entry."
+                        )
+                        _delete_thumbnail_file(
+                            thumbnail_dir_abs, db_entry.get("thumbnail_file")
+                        )
                         db_utils.delete_media_file_by_sha(db_path, sha256_hex)
                         continue
 
                     if new_sha256_hex != sha256_hex:
-                        logging.info(f"SHA changed for {rel_file_path}. Old: {sha256_hex}, New: {new_sha256_hex}. Updating DB.")
+                        logging.info(
+                            f"SHA changed for {rel_file_path}. Old: {sha256_hex}, New: {new_sha256_hex}. Updating DB."
+                        )
                         # Delete old entry (and its thumbnail)
-                        _delete_thumbnail_file(thumbnail_dir_abs, db_entry.get('thumbnail_file'))
+                        _delete_thumbnail_file(
+                            thumbnail_dir_abs, db_entry.get("thumbnail_file")
+                        )
                         db_utils.delete_media_file_by_sha(db_path, sha256_hex)
                         # The new SHA version will be picked up by the walk phase as a new file.
                         # We remove it from processed_rel_file_paths so the walk processes it.
                         processed_rel_file_paths.remove(rel_file_path)
-                    else: # SHA is the same, only mtime (and possibly other metadata) changed
-                        logging.info(f"Timestamp updated for {rel_file_path} (SHA: {sha256_hex}). Re-extracting metadata.")
+                    else:  # SHA is the same, only mtime (and possibly other metadata) changed
+                        logging.info(
+                            f"Timestamp updated for {rel_file_path} (SHA: {sha256_hex}). Re-extracting metadata."
+                        )
                         # Re-extract metadata and update DB. Thumbnail should be fine if SHA is same.
                         # However, if thumbnail was missing, try to regenerate.
-                        _process_single_file(abs_storage_dir, abs_file_path_to_check, sha256_hex, db_path, thumbnail_dir_abs, geolocator, image_classifier, settings, db_entry.get('original_filename', os.path.basename(rel_file_path)))
+                        _process_single_file(
+                            abs_storage_dir,
+                            abs_file_path_to_check,
+                            sha256_hex,
+                            db_path,
+                            thumbnail_dir_abs,
+                            geolocator,
+                            image_classifier,
+                            settings,
+                            db_entry.get(
+                                "original_filename", os.path.basename(rel_file_path)
+                            ),
+                        )
                         # No need to remove from processed_rel_file_paths, as it's updated.
                 else:
                     # File exists and last_modified is same.
                     # Check if thumbnail exists if it's supposed to.
                     mime_type, _ = mimetypes.guess_type(abs_file_path_to_check)
-                    if mime_type and mime_type.startswith('image/') and db_entry.get('thumbnail_file'):
-                        thumb_rel_path = db_entry['thumbnail_file']
-                        if not os.path.exists(os.path.join(thumbnail_dir_abs, thumb_rel_path)):
-                            logging.info(f"Thumbnail missing for {rel_file_path} (SHA: {sha256_hex}). Regenerating.")
-                            new_thumb_rel_path = generate_thumbnail(abs_file_path_to_check, thumbnail_dir_abs, sha256_hex)
+                    if (
+                        mime_type
+                        and mime_type.startswith("image/")
+                        and db_entry.get("thumbnail_file")
+                    ):
+                        thumb_rel_path = db_entry["thumbnail_file"]
+                        if not os.path.exists(
+                            os.path.join(thumbnail_dir_abs, thumb_rel_path)
+                        ):
+                            logging.info(
+                                f"Thumbnail missing for {rel_file_path} (SHA: {sha256_hex}). Regenerating."
+                            )
+                            new_thumb_rel_path = generate_thumbnail(
+                                abs_file_path_to_check, thumbnail_dir_abs, sha256_hex
+                            )
                             if new_thumb_rel_path:
-                                db_utils.update_media_file_fields(db_path, sha256_hex, {'thumbnail_file': new_thumb_rel_path})
-                    logging.debug(f"File {rel_file_path} (SHA: {sha256_hex}) is unchanged.")
+                                db_utils.update_media_file_fields(
+                                    db_path,
+                                    sha256_hex,
+                                    {"thumbnail_file": new_thumb_rel_path},
+                                )
+                    logging.debug(
+                        f"File {rel_file_path} (SHA: {sha256_hex}) is unchanged."
+                    )
 
             except OSError as e:
-                logging.error(f"Could not get metadata for file {abs_file_path_to_check} during rescan: {e}. Removing from DB.")
-                _delete_thumbnail_file(thumbnail_dir_abs, db_entry.get('thumbnail_file'))
+                logging.error(
+                    f"Could not get metadata for file {abs_file_path_to_check} during rescan: {e}. Removing from DB."
+                )
+                _delete_thumbnail_file(
+                    thumbnail_dir_abs, db_entry.get("thumbnail_file")
+                )
                 db_utils.delete_media_file_by_sha(db_path, sha256_hex)
 
-    else: # Full scan (rescan=False) or initial scan
-        logging.info(f"Performing full/initial scan of directory: {storage_dir} using DB: {db_path}")
+    else:  # Full scan (rescan=False) or initial scan
+        logging.info(
+            f"Performing full/initial scan of directory: {storage_dir} using DB: {db_path}"
+        )
         # We will iterate all files. If a file is already in DB with same mtime, we can skip.
         # Otherwise, we process and add/update.
         # Files in DB not found on disk will be handled by a cleanup phase later if rescan=False.
@@ -336,14 +420,16 @@ def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None
     # Phase 2: Walk the directory for new files or files not handled by rescan's DB check
     logging.info("Scanning filesystem for new or changed files...")
     for root, dirs, files in os.walk(abs_storage_dir):
-        if THUMBNAIL_DIR_NAME in dirs: # Correctly compare with basename
-            dirs.remove(THUMBNAIL_DIR_NAME) # Exclude .thumbnails from scan
+        if THUMBNAIL_DIR_NAME in dirs:  # Correctly compare with basename
+            dirs.remove(THUMBNAIL_DIR_NAME)  # Exclude .thumbnails from scan
 
         for disk_filename in files:
             abs_file_path = os.path.normpath(os.path.join(root, disk_filename))
             rel_file_path = os.path.relpath(abs_file_path, abs_storage_dir)
 
-            if not os.path.isfile(abs_file_path): # Should not happen with os.walk's `files`
+            if not os.path.isfile(
+                abs_file_path
+            ):  # Should not happen with os.walk's `files`
                 logging.debug(f"Skipping non-file item: {abs_file_path}")
                 continue
 
@@ -352,43 +438,89 @@ def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None
                 # or it was a file whose SHA changed and was removed from processed_rel_file_paths
                 # to be re-added here. If it's still in processed_rel_file_paths, it means it was
                 # confirmed up-to-date or mtime was updated for same SHA.
-                logging.debug(f"File {rel_file_path} already processed or checked during rescan phase.")
+                logging.debug(
+                    f"File {rel_file_path} already processed or checked during rescan phase."
+                )
                 continue
 
             if is_media_file(abs_file_path):
-                logging.debug(f"Processing media file: {abs_file_path} (relative: {rel_file_path})")
+                logging.debug(
+                    f"Processing media file: {abs_file_path} (relative: {rel_file_path})"
+                )
 
                 # Check DB for this file_path and its last_modified time
                 # This is relevant for both `rescan=True` (new files not in DB yet)
                 # and `rescan=False` (checking if file needs update)
-                db_entry_for_path = db_utils.get_media_file_by_path(db_path, rel_file_path)
+                db_entry_for_path = db_utils.get_media_file_by_path(
+                    db_path, rel_file_path
+                )
                 current_fs_last_modified = os.path.getmtime(abs_file_path)
 
-                if db_entry_for_path and \
-                   abs(current_fs_last_modified - db_entry_for_path.get('last_modified', 0.0)) < 1e-6 and \
-                   (db_entry_for_path.get('tagging_model') == settings.tagging_model or settings.tagging_model == 'Off'):
+                if (
+                    db_entry_for_path
+                    and abs(
+                        current_fs_last_modified
+                        - db_entry_for_path.get("last_modified", 0.0)
+                    )
+                    < 1e-6
+                    and (
+                        db_entry_for_path.get("tagging_model") == settings.tagging_model
+                        or settings.tagging_model == "Off"
+                    )
+                ):
                     # File exists in DB and its modification time is the same. Skip.
-                    logging.debug(f"File {rel_file_path} found in DB and is unchanged. Skipping full processing.")
-                    processed_rel_file_paths.add(rel_file_path) # Ensure it's marked
+                    logging.debug(
+                        f"File {rel_file_path} found in DB and is unchanged. Skipping full processing."
+                    )
+                    processed_rel_file_paths.add(rel_file_path)  # Ensure it's marked
                     # Check thumbnail integrity even if mtime is same
-                    if (mime_type := mimetypes.guess_type(abs_file_path)[0]) and \
-                       mime_type.startswith('image/') and \
-                       db_entry_for_path.get('thumbnail_file') and \
-                       not os.path.exists(os.path.join(thumbnail_dir_abs, db_entry_for_path['thumbnail_file'])):
-                        logging.info(f"Thumbnail missing for {rel_file_path} (SHA: {db_entry_for_path['sha256_hex']}). Regenerating.")
-                        new_thumb_rel_path = generate_thumbnail(abs_file_path, thumbnail_dir_abs, db_entry_for_path['sha256_hex'])
+                    if (
+                        (mime_type := mimetypes.guess_type(abs_file_path)[0])
+                        and mime_type.startswith("image/")
+                        and db_entry_for_path.get("thumbnail_file")
+                        and not os.path.exists(
+                            os.path.join(
+                                thumbnail_dir_abs, db_entry_for_path["thumbnail_file"]
+                            )
+                        )
+                    ):
+                        logging.info(
+                            f"Thumbnail missing for {rel_file_path} (SHA: {db_entry_for_path['sha256_hex']}). Regenerating."
+                        )
+                        new_thumb_rel_path = generate_thumbnail(
+                            abs_file_path,
+                            thumbnail_dir_abs,
+                            db_entry_for_path["sha256_hex"],
+                        )
                         if new_thumb_rel_path:
-                            db_utils.update_media_file_fields(db_path, db_entry_for_path['sha256_hex'], {'thumbnail_file': new_thumb_rel_path})
+                            db_utils.update_media_file_fields(
+                                db_path,
+                                db_entry_for_path["sha256_hex"],
+                                {"thumbnail_file": new_thumb_rel_path},
+                            )
                     continue
 
                 # If we reach here, the file is either new, or modified, or not in DB by this path.
                 # Or it's rescan=false and we are doing a full pass.
                 sha256_hex = get_file_sha256(abs_file_path)
                 if sha256_hex:
-                    _process_single_file(abs_storage_dir, abs_file_path, sha256_hex, db_path, thumbnail_dir_abs, geolocator, image_classifier, settings, disk_filename, db_entry_for_path)
+                    _process_single_file(
+                        abs_storage_dir,
+                        abs_file_path,
+                        sha256_hex,
+                        db_path,
+                        thumbnail_dir_abs,
+                        geolocator,
+                        image_classifier,
+                        settings,
+                        disk_filename,
+                        db_entry_for_path,
+                    )
                     processed_rel_file_paths.add(rel_file_path)
                 else:
-                    logging.warning(f"Could not get SHA256 for {abs_file_path}. Skipping.")
+                    logging.warning(
+                        f"Could not get SHA256 for {abs_file_path}. Skipping."
+                    )
             else:
                 logging.debug(f"Skipping non-media file: {abs_file_path}")
 
@@ -397,21 +529,28 @@ def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None
     # The previous rescan logic (Phase 1) already handles deletions for files it knew about.
     # This explicit phase ensures any file in DB not touched/seen by the walk is removed.
     if rescan:
-        logging.info("Finalizing rescan: Checking for DB entries not found on filesystem...")
+        logging.info(
+            "Finalizing rescan: Checking for DB entries not found on filesystem..."
+        )
         all_db_paths = db_utils.get_all_db_file_paths(db_path)
         for db_rel_path in all_db_paths:
             if db_rel_path not in processed_rel_file_paths:
                 # This file is in the DB but was not found on the filesystem during the walk
                 # and was not handled by the initial DB check (e.g. if it was deleted before scan started)
-                logging.info(f"File {db_rel_path} is in DB but not on filesystem. Removing from DB.")
+                logging.info(
+                    f"File {db_rel_path} is in DB but not on filesystem. Removing from DB."
+                )
                 # Need to get SHA to delete associated thumbnail
                 entry_to_delete = db_utils.get_media_file_by_path(db_path, db_rel_path)
                 if entry_to_delete:
-                    _delete_thumbnail_file(thumbnail_dir_abs, entry_to_delete.get('thumbnail_file'))
-                    db_utils.delete_media_file_by_sha(db_path, entry_to_delete['sha256_hex']) # Delete by SHA to ensure data consistency
-                else: # Should not happen if get_all_db_file_paths worked
+                    _delete_thumbnail_file(
+                        thumbnail_dir_abs, entry_to_delete.get("thumbnail_file")
+                    )
+                    db_utils.delete_media_file_by_sha(
+                        db_path, entry_to_delete["sha256_hex"]
+                    )  # Delete by SHA to ensure data consistency
+                else:  # Should not happen if get_all_db_file_paths worked
                     db_utils.delete_media_file_by_path(db_path, db_rel_path)
-
 
     # Phase 4: Synchronize .thumbnails directory: remove any orphaned thumbnails
     _cleanup_orphaned_thumbnails(db_path, thumbnail_dir_abs)
@@ -420,13 +559,28 @@ def scan_directory(storage_dir: str, db_path: str, rescan: bool = False) -> None
     if rescan:
         logging.info(f"Rescan complete. Database contains {media_count} media files.")
     else:
-        logging.info(f"Initial/Full scan complete. Database contains {media_count} media files.")
+        logging.info(
+            f"Initial/Full scan complete. Database contains {media_count} media files."
+        )
     # This function no longer returns the data directly.
     # Callers should query the DB as needed.
 
+
 import json
 
-def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: str, db_path: str, thumbnail_dir_abs: str, geolocator: GeoLocator, image_classifier: ImageClassifier, settings: SettingsManager, disk_filename: str, existing_db_entry_for_path: Optional[Dict] = None):
+
+def _process_single_file(
+    abs_storage_dir: str,
+    abs_file_path: str,
+    sha256_hex: str,
+    db_path: str,
+    thumbnail_dir_abs: str,
+    geolocator: GeoLocator,
+    image_classifier: ImageClassifier,
+    settings: SettingsManager,
+    disk_filename: str,
+    existing_db_entry_for_path: Optional[Dict] = None,
+):
     """Helper to process a single media file and update the database."""
     rel_file_path = os.path.relpath(abs_file_path, abs_storage_dir)
     logging.debug(f"Processing details for: {rel_file_path} (SHA: {sha256_hex})")
@@ -438,15 +592,28 @@ def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: s
 
     existing_entry_for_sha = db_utils.get_media_file_by_sha(db_path, sha256_hex)
 
-    if mime_type and mime_type.startswith('image/'):
-        thumbnail_relative_path = generate_thumbnail(abs_file_path, thumbnail_dir_abs, sha256_hex)
+    if mime_type and mime_type.startswith("image/"):
+        thumbnail_relative_path = generate_thumbnail(
+            abs_file_path, thumbnail_dir_abs, sha256_hex
+        )
 
-        tagging_model_in_db = existing_entry_for_sha.get('tagging_model') if existing_entry_for_sha else None
+        tagging_model_in_db = (
+            existing_entry_for_sha.get("tagging_model")
+            if existing_entry_for_sha
+            else None
+        )
 
-        if settings.tagging_model != "Off" and settings.tagging_model != tagging_model_in_db:
+        if (
+            settings.tagging_model != "Off"
+            and settings.tagging_model != tagging_model_in_db
+        ):
             tags = image_classifier.classify_image(abs_file_path)
         elif existing_entry_for_sha:
-            tags = json.loads(existing_entry_for_sha.get('tags')) if existing_entry_for_sha.get('tags') else None
+            tags = (
+                json.loads(existing_entry_for_sha.get("tags"))
+                if existing_entry_for_sha.get("tags")
+                else None
+            )
 
     try:
         last_modified = os.path.getmtime(abs_file_path)
@@ -455,7 +622,7 @@ def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: s
         image_width, image_height = None, None
         latitude, longitude, city, country = None, None, None, None
 
-        if mime_type and mime_type.startswith('image/'):
+        if mime_type and mime_type.startswith("image/"):
             try:
                 with Image.open(abs_file_path) as img:
                     image_width, image_height = img.size
@@ -473,14 +640,22 @@ def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: s
 
                         if exif_date_str:
                             try:
-                                dt_object = datetime.strptime(exif_date_str, '%Y:%m:%d %H:%M:%S')
+                                dt_object = datetime.strptime(
+                                    exif_date_str, "%Y:%m:%d %H:%M:%S"
+                                )
                                 original_creation_date = dt_object.timestamp()
                             except (ValueError, TypeError):
-                                logging.warning(f"Malformed EXIF date string '{exif_date_str}' in {abs_file_path}.")
+                                logging.warning(
+                                    f"Malformed EXIF date string '{exif_date_str}' in {abs_file_path}."
+                                )
 
-                        parsed_lat, parsed_lon = _get_gps_coordinates_from_exif(exif_data)
-                        if parsed_lat is not None: latitude = parsed_lat
-                        if parsed_lon is not None: longitude = parsed_lon
+                        parsed_lat, parsed_lon = _get_gps_coordinates_from_exif(
+                            exif_data
+                        )
+                        if parsed_lat is not None:
+                            latitude = parsed_lat
+                        if parsed_lon is not None:
+                            longitude = parsed_lon
 
                         if latitude and longitude:
                             logging.info(f"Lat: {latitude}, Lon: {longitude}")
@@ -489,7 +664,9 @@ def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: s
                                 city = closest_city.name
                                 country = closest_city.country
             except Exception as exif_e:
-                logging.warning(f"Could not read metadata for {abs_file_path}: {exif_e}.")
+                logging.warning(
+                    f"Could not read metadata for {abs_file_path}: {exif_e}."
+                )
 
         # Determine original_filename
         # If there's an existing DB entry for this SHA, use its original_filename.
@@ -497,36 +674,44 @@ def _process_single_file(abs_storage_dir: str, abs_file_path: str, sha256_hex: s
         # Otherwise (new file), use current disk_filename.
         original_filename = disk_filename
         if existing_entry_for_sha:
-            original_filename = existing_entry_for_sha.get('original_filename', disk_filename)
-        elif existing_db_entry_for_path: # File path existed, but SHA is new (file was replaced)
-             original_filename = disk_filename # Treat as new original
+            original_filename = existing_entry_for_sha.get(
+                "original_filename", disk_filename
+            )
+        elif (
+            existing_db_entry_for_path
+        ):  # File path existed, but SHA is new (file was replaced)
+            original_filename = disk_filename  # Treat as new original
 
         media_data = {
-            'sha256_hex': sha256_hex,
-            'filename': disk_filename,
-            'original_filename': original_filename,
-            'file_path': rel_file_path,
-            'last_modified': last_modified,
-            'original_creation_date': original_creation_date,
-            'thumbnail_file': thumbnail_relative_path,
-            'width': image_width,
-            'height': image_height,
-            'latitude': latitude,
-            'longitude': longitude,
-            'city': city,
-            'country': country,
-            'mime_type': mime_type,
-            'filesize': filesize,
-            'tags': json.dumps(tags) if tags else None,
-            'tagging_model': settings.tagging_model if tags else None,
+            "sha256_hex": sha256_hex,
+            "filename": disk_filename,
+            "original_filename": original_filename,
+            "file_path": rel_file_path,
+            "last_modified": last_modified,
+            "original_creation_date": original_creation_date,
+            "thumbnail_file": thumbnail_relative_path,
+            "width": image_width,
+            "height": image_height,
+            "latitude": latitude,
+            "longitude": longitude,
+            "city": city,
+            "country": country,
+            "mime_type": mime_type,
+            "filesize": filesize,
+            "tags": json.dumps(tags) if tags else None,
+            "tagging_model": settings.tagging_model if tags else None,
         }
         db_utils.add_or_update_media_file(db_path, media_data)
-        logging.debug(f"DB ADDED/UPDATED for SHA: {sha256_hex}, file: {disk_filename}, path: {rel_file_path}")
+        logging.debug(
+            f"DB ADDED/UPDATED for SHA: {sha256_hex}, file: {disk_filename}, path: {rel_file_path}"
+        )
 
     except OSError as e:
         logging.error(f"Could not get OS metadata for {abs_file_path}: {e}")
     except Exception as e:
-        logging.error(f"Unexpected error processing file {abs_file_path}: {e}", exc_info=True)
+        logging.error(
+            f"Unexpected error processing file {abs_file_path}: {e}", exc_info=True
+        )
 
 
 def _cleanup_orphaned_thumbnails(db_path: str, thumbnail_dir_abs: str):
@@ -536,28 +721,40 @@ def _cleanup_orphaned_thumbnails(db_path: str, thumbnail_dir_abs: str):
         return
 
     logging.info(f"Cleaning orphaned thumbnails in {thumbnail_dir_abs}...")
-    db_thumbnails = db_utils.get_all_shas_and_thumbnails(db_path) # {sha: thumbnail_rel_path}
+    db_thumbnails = db_utils.get_all_shas_and_thumbnails(
+        db_path
+    )  # {sha: thumbnail_rel_path}
     # Set of expected thumbnail relative paths (e.g., {"ab/hash1.png", "cd/hash2.png"})
-    expected_thumb_rel_paths = {thumb_path for thumb_path in db_thumbnails.values() if thumb_path}
+    expected_thumb_rel_paths = {
+        thumb_path for thumb_path in db_thumbnails.values() if thumb_path
+    }
 
     cleaned_count = 0
     # Walk through the thumbnail directory structure (e.g., .thumbnails/ab/hash.png)
-    for root, dirs, files in os.walk(thumbnail_dir_abs, topdown=False): # topdown=False for rmdir
+    for root, dirs, files in os.walk(
+        thumbnail_dir_abs, topdown=False
+    ):  # topdown=False for rmdir
         for file_name in files:
             if file_name.endswith(THUMBNAIL_EXTENSION):
                 # Construct the relative path of the thumbnail on disk
                 # root is like /path/to/.thumbnails/ab, file_name is hash.png
                 # We need 'ab/hash.png' to compare with expected_thumb_rel_paths
-                thumb_on_disk_rel_path = os.path.relpath(os.path.join(root, file_name), thumbnail_dir_abs)
+                thumb_on_disk_rel_path = os.path.relpath(
+                    os.path.join(root, file_name), thumbnail_dir_abs
+                )
 
                 if thumb_on_disk_rel_path not in expected_thumb_rel_paths:
                     orphaned_thumb_path_abs = os.path.join(root, file_name)
                     try:
                         os.remove(orphaned_thumb_path_abs)
-                        logging.info(f"Removed orphaned thumbnail: {orphaned_thumb_path_abs}")
-                        cleaned_count +=1
+                        logging.info(
+                            f"Removed orphaned thumbnail: {orphaned_thumb_path_abs}"
+                        )
+                        cleaned_count += 1
                     except OSError as e:
-                        logging.error(f"Error removing orphaned thumbnail {orphaned_thumb_path_abs}: {e}")
+                        logging.error(
+                            f"Error removing orphaned thumbnail {orphaned_thumb_path_abs}: {e}"
+                        )
 
         # After removing files in a directory, if the directory is empty, remove it
         # This applies only to subdirectories (e.g. .thumbnails/ab), not the main .thumbnails dir
@@ -566,5 +763,7 @@ def _cleanup_orphaned_thumbnails(db_path: str, thumbnail_dir_abs: str):
                 os.rmdir(root)
                 logging.info(f"Removed empty thumbnail subdirectory: {root}")
             except OSError as e:
-                logging.error(f"Error removing empty thumbnail subdirectory {root}: {e}")
+                logging.error(
+                    f"Error removing empty thumbnail subdirectory {root}: {e}"
+                )
     logging.info(f"Orphaned thumbnail cleanup complete. Removed {cleaned_count} files.")

--- a/media_server/server.py
+++ b/media_server/server.py
@@ -3,8 +3,10 @@ import os
 import sys
 
 # Ensure the project root is in sys.path for direct execution
-if __name__ == '__main__' and __package__ is None:
-    PROJECT_ROOT_FOR_SERVER = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if __name__ == "__main__" and __package__ is None:
+    PROJECT_ROOT_FOR_SERVER = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..")
+    )
     if PROJECT_ROOT_FOR_SERVER not in sys.path:
         sys.path.insert(0, PROJECT_ROOT_FOR_SERVER)
 
@@ -13,10 +15,10 @@ import threading
 import time
 import datetime
 import hashlib
-import mimetypes # for guessing mime type of uploaded file
+import mimetypes  # for guessing mime type of uploaded file
 from werkzeug.utils import secure_filename
 from werkzeug.exceptions import NotFound
-from flask import request, g as flask_g # Added g for db connection per request
+from flask import request, g as flask_g  # Added g for db connection per request
 
 from absl import app as absl_app
 from absl import flags, logging
@@ -28,7 +30,7 @@ try:
     from . import database as db_utils
     from . import settings as settings_utils
 except ImportError:
-    from media_server import media_scanner # Fallback for direct execution
+    from media_server import media_scanner  # Fallback for direct execution
     from media_server import database as db_utils
     from media_server import settings as settings_utils
 
@@ -37,20 +39,25 @@ FLAGS = flags.FLAGS
 
 # Define flags if not already defined
 try:
-    flags.DEFINE_string('storage_dir', None, 'Directory to scan for media files.')
-    flags.DEFINE_integer('port', 8000, 'Port for the HTTP server.')
-    flags.DEFINE_string('db_name', db_utils.DATABASE_NAME, 'Name of the SQLite database file.')
-    if __name__ == "__main__": # Mark as required only if this script is the entry point
-        flags.mark_flag_as_required('storage_dir')
+    flags.DEFINE_string("storage_dir", None, "Directory to scan for media files.")
+    flags.DEFINE_integer("port", 8000, "Port for the HTTP server.")
+    flags.DEFINE_string(
+        "db_name", db_utils.DATABASE_NAME, "Name of the SQLite database file."
+    )
+    if (
+        __name__ == "__main__"
+    ):  # Mark as required only if this script is the entry point
+        flags.mark_flag_as_required("storage_dir")
 except flags.Error:
-    pass # Flags are already defined
+    pass  # Flags are already defined
 
 
 # Determine the absolute path to the project's root directory
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-WEB_DIR_ABSOLUTE = os.path.join(PROJECT_ROOT, 'web')
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+WEB_DIR_ABSOLUTE = os.path.join(PROJECT_ROOT, "web")
 
-app = Flask(__name__, static_folder=WEB_DIR_ABSOLUTE, static_url_path='')
+app = Flask(__name__, static_folder=WEB_DIR_ABSOLUTE, static_url_path="")
+
 
 # --- Database Connection Handling ---
 def get_db():
@@ -63,8 +70,8 @@ def get_db():
     Returns:
         A sqlite3.Connection object.
     """
-    if not hasattr(flask_g, 'sqlite_db'):
-        db_path = app.config.get('DATABASE_PATH')
+    if not hasattr(flask_g, "sqlite_db"):
+        db_path = app.config.get("DATABASE_PATH")
         if not db_path:
             # This should ideally not happen if app is configured correctly
             logging.error("DATABASE_PATH not configured in Flask app.")
@@ -79,10 +86,13 @@ def get_db():
             # Background thread needs its own connection management.
             # The db_utils.thread_local should handle this.
             # This flask_g based one is for request threads.
-            flask_g.sqlite_db = db_utils.get_db_connection(db_utils.get_db_path(app.config.get('STORAGE_DIR')))
+            flask_g.sqlite_db = db_utils.get_db_connection(
+                db_utils.get_db_path(app.config.get("STORAGE_DIR"))
+            )
         else:
             flask_g.sqlite_db = db_utils.get_db_connection(db_path)
     return flask_g.sqlite_db
+
 
 @app.teardown_appcontext
 def close_db(error):
@@ -95,14 +105,18 @@ def close_db(error):
     Args:
         error: An exception that occurred during the request, if any.
     """
-    if hasattr(flask_g, 'sqlite_db'):
-        db_utils.close_db_connection() # This uses thread_local.connection
-        delattr(flask_g, 'sqlite_db') # Remove from flask_g
+    if hasattr(flask_g, "sqlite_db"):
+        db_utils.close_db_connection()  # This uses thread_local.connection
+        delattr(flask_g, "sqlite_db")  # Remove from flask_g
+
 
 # --- Background Scanner ---
 scanner_wakeup_event = threading.Event()
 
-def background_scanner_task(app_context, settings_manager_instance: settings_utils.SettingsManager):
+
+def background_scanner_task(
+    app_context, settings_manager_instance: settings_utils.SettingsManager
+):
     """
     A background task that periodically rescans the storage directory.
 
@@ -118,28 +132,36 @@ def background_scanner_task(app_context, settings_manager_instance: settings_uti
     # The app_context is passed to allow the thread to configure logging or other app settings if needed
     # but primarily for accessing app.config values like STORAGE_DIR and DATABASE_PATH.
 
-    with app_context: # Use the app context for config access
-        storage_dir = app.config.get('STORAGE_DIR')
-        db_path = app.config.get('DATABASE_PATH') # Get the configured DB path
+    with app_context:  # Use the app context for config access
+        storage_dir = app.config.get("STORAGE_DIR")
+        db_path = app.config.get("DATABASE_PATH")  # Get the configured DB path
 
         if not storage_dir or not db_path:
-            logging.error("Background scanner cannot start: storage_dir or db_path not configured properly.")
+            logging.error(
+                "Background scanner cannot start: storage_dir or db_path not configured properly."
+            )
             return
 
-        logging.info(f"Background scanner started for dir: {storage_dir}, DB: {db_path}")
+        logging.info(
+            f"Background scanner started for dir: {storage_dir}, DB: {db_path}"
+        )
         while True:
             rescan_interval = settings_manager_instance.get().rescan_interval
             if rescan_interval <= 0:
-                logging.info("Rescanning is disabled, scanner will sleep until settings change.")
-                scanner_wakeup_event.wait() # Wait indefinitely until event is set
-                scanner_wakeup_event.clear() # Clear the event after waking up
+                logging.info(
+                    "Rescanning is disabled, scanner will sleep until settings change."
+                )
+                scanner_wakeup_event.wait()  # Wait indefinitely until event is set
+                scanner_wakeup_event.clear()  # Clear the event after waking up
                 logging.info("Scanner woken up by settings change.")
                 continue
 
             try:
                 # The db_utils.get_db_connection() called by media_scanner will use thread_local
                 # to get/create a connection for this background thread.
-                logging.info(f"Background scanner performing rescan... (Interval: {rescan_interval}s)")
+                logging.info(
+                    f"Background scanner performing rescan... (Interval: {rescan_interval}s)"
+                )
                 media_scanner.scan_directory(storage_dir, db_path, rescan=True)
                 logging.info("Background rescan complete.")
             except Exception as e:
@@ -157,7 +179,7 @@ def background_scanner_task(app_context, settings_manager_instance: settings_uti
 
 
 # --- Flask Routes ---
-@app.route('/')
+@app.route("/")
 def root():
     """
     Serves the main `index.html` page.
@@ -165,9 +187,10 @@ def root():
     Returns:
         The `index.html` file from the static folder.
     """
-    return app.send_static_file('index.html')
+    return app.send_static_file("index.html")
 
-@app.route('/list', methods=['GET'])
+
+@app.route("/list", methods=["GET"])
 def list_media():
     """
     Returns a list of all media files in the database.
@@ -183,11 +206,12 @@ def list_media():
     # db_utils functions now use app.config['DATABASE_PATH'] via their own get_db_path if flask_g not set,
     # or directly use the connection from flask_g if set by get_db().
     # The crucial part is that db_utils.get_db_connection gets the correct db_path.
-    all_media = db_utils.get_all_media_files(app.config['DATABASE_PATH'])
+    all_media = db_utils.get_all_media_files(app.config["DATABASE_PATH"])
     logging.info(f"Served /list request, found {len(all_media)} items.")
     return jsonify(all_media)
 
-@app.route('/list/date/<string:date_str>', methods=['GET'])
+
+@app.route("/list/date/<string:date_str>", methods=["GET"])
 def list_media_by_date(date_str):
     """
     Lists media files for a specific date.
@@ -195,26 +219,33 @@ def list_media_by_date(date_str):
     """
     try:
         # Convert YYYY-MM-DD string to a datetime object, then to a timestamp
-        dt_obj = datetime.datetime.strptime(date_str, '%Y-%m-%d')
+        dt_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d")
         # To get a full day, we can find the start and end of the day.
         # However, the DB function get_media_files_by_date uses date() SQL function,
         # so passing the timestamp of the beginning of the day is sufficient.
         timestamp = dt_obj.timestamp()
-        media_files = db_utils.get_media_files_by_date(app.config['DATABASE_PATH'], timestamp)
-        logging.info(f"Served /list/date/{date_str} request, found {len(media_files)} items.")
+        media_files = db_utils.get_media_files_by_date(
+            app.config["DATABASE_PATH"], timestamp
+        )
+        logging.info(
+            f"Served /list/date/{date_str} request, found {len(media_files)} items."
+        )
         return jsonify(media_files)
     except ValueError:
         abort(400, description="Invalid date format. Please use YYYY-MM-DD.")
 
-@app.route('/list/daterange/<string:start_date_str>/<string:end_date_str>', methods=['GET'])
+
+@app.route(
+    "/list/daterange/<string:start_date_str>/<string:end_date_str>", methods=["GET"]
+)
 def list_media_by_date_range(start_date_str, end_date_str):
     """
     Lists media files within a date range.
     Date format should be YYYY-MM-DD.
     """
     try:
-        start_dt = datetime.datetime.strptime(start_date_str, '%Y-%m-%d')
-        end_dt = datetime.datetime.strptime(end_date_str, '%Y-%m-%d')
+        start_dt = datetime.datetime.strptime(start_date_str, "%Y-%m-%d")
+        end_dt = datetime.datetime.strptime(end_date_str, "%Y-%m-%d")
         # To be inclusive of the end date, set time to end of day
         end_dt = end_dt.replace(hour=23, minute=59, second=59)
 
@@ -224,24 +255,35 @@ def list_media_by_date_range(start_date_str, end_date_str):
         if start_timestamp > end_timestamp:
             abort(400, description="Start date must be before end date.")
 
-        media_files = db_utils.get_media_files_by_date_range(app.config['DATABASE_PATH'], start_timestamp, end_timestamp)
-        logging.info(f"Served /list/daterange/ request from {start_date_str} to {end_date_str}, found {len(media_files)} items.")
+        media_files = db_utils.get_media_files_by_date_range(
+            app.config["DATABASE_PATH"], start_timestamp, end_timestamp
+        )
+        logging.info(
+            f"Served /list/daterange/ request from {start_date_str} to {end_date_str}, found {len(media_files)} items."
+        )
         return jsonify(media_files)
     except ValueError:
         abort(400, description="Invalid date format. Please use YYYY-MM-DD.")
 
-@app.route('/list/location/<string:city>', methods=['GET'])
-@app.route('/list/location/<string:city>/<string:country>', methods=['GET'])
+
+@app.route("/list/location/<string:city>", methods=["GET"])
+@app.route("/list/location/<string:city>/<string:country>", methods=["GET"])
 def list_media_by_location(city, country=None):
     """
     Lists media files for a specific location (city and optional country).
     """
-    media_files = db_utils.get_media_files_by_location(app.config['DATABASE_PATH'], city, country)
+    media_files = db_utils.get_media_files_by_location(
+        app.config["DATABASE_PATH"], city, country
+    )
     location_str = f"{city}/{country}" if country else city
-    logging.info(f"Served /list/location/{location_str} request, found {len(media_files)} items.")
+    logging.info(
+        f"Served /list/location/{location_str} request, found {len(media_files)} items."
+    )
     return jsonify(media_files)
 
-ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'heic', 'heif', 'mp4', 'mov', 'avi'}
+
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "heic", "heif", "mp4", "mov", "avi"}
+
 
 def allowed_file(filename):
     """
@@ -253,11 +295,11 @@ def allowed_file(filename):
     Returns:
         True if the filename has an allowed extension, False otherwise.
     """
-    return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
-@app.route('/image/<path:filename>', methods=['PUT'])
-def put_image(filename): # filename comes from the <path:filename> URL part
+
+@app.route("/image/<path:filename>", methods=["PUT"])
+def put_image(filename):  # filename comes from the <path:filename> URL part
     """
     Handles image uploads via PUT request.
 
@@ -271,48 +313,61 @@ def put_image(filename): # filename comes from the <path:filename> URL part
     Returns:
         A JSON response with details of the uploaded image or an error message.
     """
-    if 'file' not in request.files:
+    if "file" not in request.files:
         abort(400, description="No file part in the request.")
 
-    file_from_request = request.files['file']
-    original_client_filename = file_from_request.filename # Original name from client
+    file_from_request = request.files["file"]
+    original_client_filename = file_from_request.filename  # Original name from client
 
-    if original_client_filename == '':
+    if original_client_filename == "":
         abort(400, description="No selected file.")
 
     if not allowed_file(original_client_filename):
-        abort(400, description=f"Invalid file type for '{original_client_filename}'. Allowed: {ALLOWED_EXTENSIONS}")
+        abort(
+            400,
+            description=f"Invalid file type for '{original_client_filename}'. Allowed: {ALLOWED_EXTENSIONS}",
+        )
 
     # Sanitize the filename from URL, or use sanitized client filename if URL one is bad
-    s_filename = secure_filename(filename) # Use the 'filename' arg from the route
+    s_filename = secure_filename(filename)  # Use the 'filename' arg from the route
     if not s_filename:
         s_filename = secure_filename(original_client_filename)
-        if not s_filename: # If both are bad, create a default
-             s_filename = "unnamed_upload" + os.path.splitext(original_client_filename)[1].lower()
+        if not s_filename:  # If both are bad, create a default
+            s_filename = (
+                "unnamed_upload" + os.path.splitext(original_client_filename)[1].lower()
+            )
 
     file_contents = file_from_request.read()
     sha256_hash = hashlib.sha256(file_contents).hexdigest()
-    db_path = app.config['DATABASE_PATH']
+    db_path = app.config["DATABASE_PATH"]
 
     existing_entry = db_utils.get_media_file_by_sha(db_path, sha256_hash)
     if existing_entry:
-        logging.info(f"Image with SHA256 {sha256_hash} (filename: {s_filename}) already exists in DB. Path: {existing_entry.get('file_path')}")
-        return jsonify({
-            "message": "Image content already exists in DB.",
-            "sha256": sha256_hash,
-            "filename": existing_entry.get('filename'),
-            "file_path": existing_entry.get('file_path')
-        }), 200 # OK, content already present
+        logging.info(
+            f"Image with SHA256 {sha256_hash} (filename: {s_filename}) already exists in DB. Path: {existing_entry.get('file_path')}"
+        )
+        return (
+            jsonify(
+                {
+                    "message": "Image content already exists in DB.",
+                    "sha256": sha256_hash,
+                    "filename": existing_entry.get("filename"),
+                    "file_path": existing_entry.get("file_path"),
+                }
+            ),
+            200,
+        )  # OK, content already present
 
     # Determine save path
-    today_str = datetime.datetime.now().strftime('%Y%m%d')
-    upload_subdir_rel = os.path.join("uploads", today_str) # Relative to storage_dir
-    upload_dir_abs = os.path.join(app.config['STORAGE_DIR'], upload_subdir_rel)
+    today_str = datetime.datetime.now().strftime("%Y%m%d")
+    upload_subdir_rel = os.path.join("uploads", today_str)  # Relative to storage_dir
+    upload_dir_abs = os.path.join(app.config["STORAGE_DIR"], upload_subdir_rel)
     os.makedirs(upload_dir_abs, exist_ok=True)
 
     base, ext = os.path.splitext(s_filename)
     ext = ext.lower()
-    if not base and ext: base = "image" # Handle cases like ".jpg"
+    if not base and ext:
+        base = "image"  # Handle cases like ".jpg"
 
     final_filename_on_disk = f"{base}{ext}"
     prospective_path_on_disk_abs = os.path.join(upload_dir_abs, final_filename_on_disk)
@@ -320,14 +375,20 @@ def put_image(filename): # filename comes from the <path:filename> URL part
     while os.path.exists(prospective_path_on_disk_abs):
         counter += 1
         final_filename_on_disk = f"{base}_{counter}{ext}"
-        prospective_path_on_disk_abs = os.path.join(upload_dir_abs, final_filename_on_disk)
+        prospective_path_on_disk_abs = os.path.join(
+            upload_dir_abs, final_filename_on_disk
+        )
 
     try:
         with open(prospective_path_on_disk_abs, "wb") as f_save:
             f_save.write(file_contents)
-        logging.info(f"Saved new image: {final_filename_on_disk} to {upload_subdir_rel} (SHA256: {sha256_hash})")
+        logging.info(
+            f"Saved new image: {final_filename_on_disk} to {upload_subdir_rel} (SHA256: {sha256_hash})"
+        )
     except IOError as e:
-        logging.error(f"Failed to save file {final_filename_on_disk} to {upload_dir_abs}: {e}")
+        logging.error(
+            f"Failed to save file {final_filename_on_disk} to {upload_dir_abs}: {e}"
+        )
         abort(500, description="Failed to save image to disk.")
 
     # Process the newly saved file to add it to the database
@@ -335,28 +396,29 @@ def put_image(filename): # filename comes from the <path:filename> URL part
     # _process_single_file needs abs_storage_dir, abs_file_path, sha, db_path, thumbnail_dir_abs, disk_filename
     # We can call a simplified version or directly populate media_data
 
-    thumbnail_dir_abs = app.config['THUMBNAIL_DIR']
+    thumbnail_dir_abs = app.config["THUMBNAIL_DIR"]
     thumbnail_relative_path = None
     mime_type_upload, _ = mimetypes.guess_type(prospective_path_on_disk_abs)
     filesize = os.path.getsize(prospective_path_on_disk_abs)
 
-
-    if mime_type_upload and mime_type_upload.startswith('image/'):
+    if mime_type_upload and mime_type_upload.startswith("image/"):
         thumbnail_relative_path = media_scanner.generate_thumbnail(
-            prospective_path_on_disk_abs,
-            thumbnail_dir_abs,
-            sha256_hash
+            prospective_path_on_disk_abs, thumbnail_dir_abs, sha256_hash
         )
 
     # Extract metadata (simplified from _process_single_file)
     last_modified = os.path.getmtime(prospective_path_on_disk_abs)
-    original_creation_date = os.path.getctime(prospective_path_on_disk_abs) # Default
+    original_creation_date = os.path.getctime(prospective_path_on_disk_abs)  # Default
     image_width, image_height = None, None
     latitude, longitude = None, None
 
-    if mime_type_upload and mime_type_upload.startswith('image/'):
+    if mime_type_upload and mime_type_upload.startswith("image/"):
         try:
-            from PIL import Image as PILImage, ExifTags as PILExifTags # Local import for safety
+            from PIL import (
+                Image as PILImage,
+                ExifTags as PILExifTags,
+            )  # Local import for safety
+
             with PILImage.open(prospective_path_on_disk_abs) as img:
                 image_width, image_height = img.size
                 exif_data = img.getexif()
@@ -373,49 +435,64 @@ def put_image(filename): # filename comes from the <path:filename> URL part
 
                     if exif_date_str:
                         try:
-                            dt_obj = datetime.datetime.strptime(exif_date_str, '%Y:%m:%d %H:%M:%S')
+                            dt_obj = datetime.datetime.strptime(
+                                exif_date_str, "%Y:%m:%d %H:%M:%S"
+                            )
                             original_creation_date = dt_obj.timestamp()
                         except (ValueError, TypeError):
-                            logging.warning(f"Malformed EXIF date string '{exif_date_str}' in uploaded file.")
+                            logging.warning(
+                                f"Malformed EXIF date string '{exif_date_str}' in uploaded file."
+                            )
 
                     lat, lon = media_scanner._get_gps_coordinates_from_exif(exif_data)
-                    if lat is not None: latitude = lat
-                    if lon is not None: longitude = lon
+                    if lat is not None:
+                        latitude = lat
+                    if lon is not None:
+                        longitude = lon
         except Exception as e:
-            logging.warning(f"Could not read full EXIF for uploaded {final_filename_on_disk}: {e}")
+            logging.warning(
+                f"Could not read full EXIF for uploaded {final_filename_on_disk}: {e}"
+            )
 
     relative_file_path_for_db = os.path.join(upload_subdir_rel, final_filename_on_disk)
     media_data = {
-        'sha256_hex': sha256_hash,
-        'filename': final_filename_on_disk, # Name on disk in its upload subfolder
-        'original_filename': original_client_filename, # Original name from client
-        'file_path': relative_file_path_for_db, # Relative to storage_dir
-        'last_modified': last_modified,
-        'original_creation_date': original_creation_date,
-        'thumbnail_file': thumbnail_relative_path,
-        'width': image_width,
-        'height': image_height,
-        'latitude': latitude,
-        'longitude': longitude,
-        'mime_type': mime_type_upload,
-        'filesize': filesize
-    }
-    db_utils.add_or_update_media_file(db_path, media_data)
-    logging.info(f"DB entry created for uploaded SHA256: {sha256_hash}, file {final_filename_on_disk}")
-
-    return jsonify({
-        "message": "Image uploaded and processed successfully.",
-        "sha256": sha256_hash,
-        "filename": final_filename_on_disk,
-        "file_path": relative_file_path_for_db,
+        "sha256_hex": sha256_hash,
+        "filename": final_filename_on_disk,  # Name on disk in its upload subfolder
+        "original_filename": original_client_filename,  # Original name from client
+        "file_path": relative_file_path_for_db,  # Relative to storage_dir
+        "last_modified": last_modified,
+        "original_creation_date": original_creation_date,
         "thumbnail_file": thumbnail_relative_path,
         "width": image_width,
-        "height": image_height
-    }), 201
+        "height": image_height,
+        "latitude": latitude,
+        "longitude": longitude,
+        "mime_type": mime_type_upload,
+        "filesize": filesize,
+    }
+    db_utils.add_or_update_media_file(db_path, media_data)
+    logging.info(
+        f"DB entry created for uploaded SHA256: {sha256_hash}, file {final_filename_on_disk}"
+    )
+
+    return (
+        jsonify(
+            {
+                "message": "Image uploaded and processed successfully.",
+                "sha256": sha256_hash,
+                "filename": final_filename_on_disk,
+                "file_path": relative_file_path_for_db,
+                "thumbnail_file": thumbnail_relative_path,
+                "width": image_width,
+                "height": image_height,
+            }
+        ),
+        201,
+    )
 
 
-@app.route('/image/<string:sha256_hex>', methods=['GET'])
-@app.route('/image/sha256/<string:sha256_hex>', methods=['GET']) # Alias
+@app.route("/image/<string:sha256_hex>", methods=["GET"])
+@app.route("/image/sha256/<string:sha256_hex>", methods=["GET"])  # Alias
 def get_image(sha256_hex):
     """
     Serves an image file based on its SHA256 hash.
@@ -426,22 +503,28 @@ def get_image(sha256_hex):
     Returns:
         The image file as a response, or a 404 error if not found.
     """
-    if not (len(sha256_hex) == 64 and all(c in '0123456789abcdefABCDEF' for c in sha256_hex)):
+    if not (
+        len(sha256_hex) == 64 and all(c in "0123456789abcdefABCDEF" for c in sha256_hex)
+    ):
         abort(400, description="Invalid SHA256 format.")
 
-    db_entry = db_utils.get_media_file_by_sha(app.config['DATABASE_PATH'], sha256_hex)
+    db_entry = db_utils.get_media_file_by_sha(app.config["DATABASE_PATH"], sha256_hex)
     if not db_entry:
         abort(404, description="Image not found (SHA unknown in DB).")
 
-    file_path_relative = db_entry.get('file_path')
+    file_path_relative = db_entry.get("file_path")
     if not file_path_relative:
-        abort(500, description="Server error: Image metadata incomplete in DB (no file_path).")
+        abort(
+            500,
+            description="Server error: Image metadata incomplete in DB (no file_path).",
+        )
 
-    storage_dir_abs = app.config['STORAGE_DIR']
+    storage_dir_abs = app.config["STORAGE_DIR"]
     # Security check (already in db_utils.get_media_file_by_sha, but defense in depth)
     full_file_path = os.path.normpath(os.path.join(storage_dir_abs, file_path_relative))
-    if not full_file_path.startswith(os.path.normpath(storage_dir_abs) + os.sep) and \
-       not full_file_path == os.path.normpath(storage_dir_abs):
+    if not full_file_path.startswith(
+        os.path.normpath(storage_dir_abs) + os.sep
+    ) and not full_file_path == os.path.normpath(storage_dir_abs):
         abort(400, description="Invalid file path generated.")
 
     try:
@@ -452,14 +535,16 @@ def get_image(sha256_hex):
 
 settings_manager: settings_utils.SettingsManager = None
 
-@app.route('/api/settings', methods=['GET'])
+
+@app.route("/api/settings", methods=["GET"])
 def get_settings():
     """
     Returns the current application settings.
     """
     return jsonify(dataclasses.asdict(settings_manager.get()))
 
-@app.route('/api/settings', methods=['PUT'])
+
+@app.route("/api/settings", methods=["PUT"])
 def put_settings():
     """
     Updates the application settings.
@@ -473,7 +558,9 @@ def put_settings():
         settings_manager.write_settings(new_settings)
 
         if current_settings.rescan_interval <= 0 and new_settings.rescan_interval > 0:
-            logging.info("Rescan interval changed from disabled to enabled, waking up scanner.")
+            logging.info(
+                "Rescan interval changed from disabled to enabled, waking up scanner."
+            )
             scanner_wakeup_event.set()
 
         return jsonify(dataclasses.asdict(new_settings))
@@ -481,7 +568,7 @@ def put_settings():
         abort(400, description=f"Invalid settings format: {e}")
 
 
-@app.route('/thumbnail/<string:sha256_hex>', methods=['GET'])
+@app.route("/thumbnail/<string:sha256_hex>", methods=["GET"])
 def get_thumbnail(sha256_hex):
     """
     Serves a thumbnail image for a given SHA256 hash.
@@ -492,38 +579,51 @@ def get_thumbnail(sha256_hex):
     Returns:
         The thumbnail image file as a response, or a 404 error if not found.
     """
-    if not (len(sha256_hex) == 64 and all(c in '0123456789abcdefABCDEF' for c in sha256_hex)):
+    if not (
+        len(sha256_hex) == 64 and all(c in "0123456789abcdefABCDEF" for c in sha256_hex)
+    ):
         abort(400, description="Invalid SHA256 format.")
 
-    db_entry = db_utils.get_media_file_by_sha(app.config['DATABASE_PATH'], sha256_hex)
+    db_entry = db_utils.get_media_file_by_sha(app.config["DATABASE_PATH"], sha256_hex)
     if not db_entry:
         abort(404, description="Image SHA not found in DB, so no thumbnail.")
 
-    thumbnail_relative_path = db_entry.get('thumbnail_file')
+    thumbnail_relative_path = db_entry.get("thumbnail_file")
     if not thumbnail_relative_path:
         # This could be a non-image file, or thumbnail generation failed.
         # Check mime type from db_entry to return more specific error or placeholder
-        mime_type = db_entry.get('mime_type')
-        if mime_type and mime_type.startswith('video/'):
-             # TODO: Could serve a generic video icon thumbnail later
-            abort(404, description=f"Thumbnails not supported for video type {mime_type} yet, or this video has no thumbnail.")
+        mime_type = db_entry.get("mime_type")
+        if mime_type and mime_type.startswith("video/"):
+            # TODO: Could serve a generic video icon thumbnail later
+            abort(
+                404,
+                description=f"Thumbnails not supported for video type {mime_type} yet, or this video has no thumbnail.",
+            )
         abort(404, description="Thumbnail not available for this item.")
 
-    thumbnail_dir_abs = app.config['THUMBNAIL_DIR']
-    if not os.path.isdir(thumbnail_dir_abs): # Should have been created by scanner
-        abort(500, description="Thumbnail directory misconfigured or missing on server.")
+    thumbnail_dir_abs = app.config["THUMBNAIL_DIR"]
+    if not os.path.isdir(thumbnail_dir_abs):  # Should have been created by scanner
+        abort(
+            500, description="Thumbnail directory misconfigured or missing on server."
+        )
 
     # Security check for thumbnail_relative_path (e.g. 'ab/hash.png')
     # Ensure it doesn't try to escape thumbnail_dir_abs
-    full_thumb_path = os.path.normpath(os.path.join(thumbnail_dir_abs, thumbnail_relative_path))
+    full_thumb_path = os.path.normpath(
+        os.path.join(thumbnail_dir_abs, thumbnail_relative_path)
+    )
     if not full_thumb_path.startswith(os.path.normpath(thumbnail_dir_abs) + os.sep):
         abort(400, description="Invalid thumbnail path.")
 
     try:
-        return send_from_directory(thumbnail_dir_abs, thumbnail_relative_path, mimetype='image/png')
+        return send_from_directory(
+            thumbnail_dir_abs, thumbnail_relative_path, mimetype="image/png"
+        )
     except NotFound:
-         # This implies DB has a thumbnail_file entry, but the file is missing.
-        logging.warning(f"Thumbnail file {thumbnail_relative_path} for SHA {sha256_hex} not found on disk (DB out of sync?).")
+        # This implies DB has a thumbnail_file entry, but the file is missing.
+        logging.warning(
+            f"Thumbnail file {thumbnail_relative_path} for SHA {sha256_hex} not found on disk (DB out of sync?)."
+        )
         # Scanner should ideally clean this up or regenerate.
         abort(404, description="Thumbnail file missing on disk.")
 
@@ -538,7 +638,7 @@ def run_flask_app(argv):
     Args:
         argv: Command-line arguments passed to the application.
     """
-    del argv # Unused.
+    del argv  # Unused.
 
     logging.set_verbosity(logging.INFO)
 
@@ -549,62 +649,78 @@ def run_flask_app(argv):
 
     # Make storage_dir absolute
     storage_dir = os.path.abspath(storage_dir)
-    os.makedirs(storage_dir, exist_ok=True) # Ensure storage_dir exists
+    os.makedirs(storage_dir, exist_ok=True)  # Ensure storage_dir exists
 
-    app.config['STORAGE_DIR'] = storage_dir
-    app.config['THUMBNAIL_DIR'] = os.path.join(storage_dir, media_scanner.THUMBNAIL_DIR_NAME)
-    os.makedirs(app.config['THUMBNAIL_DIR'], exist_ok=True) # Ensure .thumbnails exists
+    app.config["STORAGE_DIR"] = storage_dir
+    app.config["THUMBNAIL_DIR"] = os.path.join(
+        storage_dir, media_scanner.THUMBNAIL_DIR_NAME
+    )
+    os.makedirs(app.config["THUMBNAIL_DIR"], exist_ok=True)  # Ensure .thumbnails exists
 
     # Database path configuration
     # db_utils.get_db_path will use this name inside storage_dir
-    app.config['DATABASE_PATH'] = db_utils.get_db_path(storage_dir) # FLAGS.db_name is just the filename
+    app.config["DATABASE_PATH"] = db_utils.get_db_path(
+        storage_dir
+    )  # FLAGS.db_name is just the filename
 
     logging.info(f"Storage directory: {app.config['STORAGE_DIR']}")
     logging.info(f"Thumbnail directory: {app.config['THUMBNAIL_DIR']}")
     logging.info(f"Database path: {app.config['DATABASE_PATH']}")
 
     global settings_manager
-    settings_manager = settings_utils.SettingsManager(os.path.join(storage_dir, 'settings.json'))
-
+    settings_manager = settings_utils.SettingsManager(
+        os.path.join(storage_dir, "settings.json")
+    )
 
     # Initialize DB (create tables if not exist)
     # This init_db is for the main thread. It will use its own connection.
     try:
-        db_utils.init_db(storage_dir) # Pass storage_dir so it can construct the correct db_path
+        db_utils.init_db(
+            storage_dir
+        )  # Pass storage_dir so it can construct the correct db_path
     except Exception as e:
-        logging.error(f"Failed to initialize database at {app.config['DATABASE_PATH']}: {e}", exc_info=True)
+        logging.error(
+            f"Failed to initialize database at {app.config['DATABASE_PATH']}: {e}",
+            exc_info=True,
+        )
         sys.exit(1)
     finally:
-        db_utils.close_db_connection() # Close connection for main thread after init
+        db_utils.close_db_connection()  # Close connection for main thread after init
 
     # Initial scan of the media directory (rescan=False)
-    logging.info(f"Performing initial scan of storage directory: {app.config['STORAGE_DIR']}")
+    logging.info(
+        f"Performing initial scan of storage directory: {app.config['STORAGE_DIR']}"
+    )
     try:
-        media_scanner.scan_directory(app.config['STORAGE_DIR'], app.config['DATABASE_PATH'], rescan=False)
+        media_scanner.scan_directory(
+            app.config["STORAGE_DIR"], app.config["DATABASE_PATH"], rescan=False
+        )
     except Exception as e:
         logging.error(f"Error during initial scan: {e}", exc_info=True)
         # Decide if server should start if initial scan fails. For now, it will.
     finally:
-        db_utils.close_db_connection() # Close connection for main thread after scan
+        db_utils.close_db_connection()  # Close connection for main thread after scan
 
-    num_items_in_db = len(db_utils.get_all_media_files(app.config['DATABASE_PATH']))
+    num_items_in_db = len(db_utils.get_all_media_files(app.config["DATABASE_PATH"]))
     logging.info(f"Initial scan complete. Database contains {num_items_in_db} items.")
-    db_utils.close_db_connection() # Close again, just in case get_all_media_files opened one.
+    db_utils.close_db_connection()  # Close again, just in case get_all_media_files opened one.
 
     # The background scanner will start and then manage its own loop and sleep interval
     # based on the settings. It no longer depends on a startup flag to be enabled.
     scanner_thread = threading.Thread(
         target=background_scanner_task,
         args=(app.app_context(), settings_manager),
-        daemon=True
+        daemon=True,
     )
     scanner_thread.start()
 
     logging.info(f"Starting Flask HTTP server on port {FLAGS.port}...")
-    app.run(host='0.0.0.0', port=FLAGS.port, debug=False, use_reloader=False)
+    app.run(host="0.0.0.0", port=FLAGS.port, debug=False, use_reloader=False)
+
 
 def main_flask():
     absl_app.run(run_flask_app)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main_flask()

--- a/media_server/settings.py
+++ b/media_server/settings.py
@@ -2,13 +2,16 @@ import dataclasses
 import json
 from typing import Literal, Optional
 
+
 @dataclasses.dataclass
 class Settings:
     """A data class representing the application settings."""
+
     rescan_interval: int = 600
     tagging_model: Literal["Resnet", "Mobilenet", "Off"] = "Off"
     archival_backend: Literal["Google Cloud", "AWS", "Off"] = "Off"
     archival_bucket: str = ""
+
 
 class SettingsManager:
     """A class to manage the application settings."""


### PR DESCRIPTION
This commit introduces the following changes:

- The `media_files` table in the database now stores the name of the model used to generate the tags for each media file.
- When the `tagging_model` in the settings is changed, the media scanner will now regenerate the tags for all media files using the new model.
- A new test case has been added to verify that the `tagging_model` is stored correctly and that the tags are regenerated on model change.